### PR TITLE
Refactor getmodel and init

### DIFF
--- a/src/getmodel/getmodel.cpp
+++ b/src/getmodel/getmodel.cpp
@@ -40,6 +40,7 @@
 #include <list>
 #include <set>
 #include <map>
+#include <memory>
 #include "getmodel.h"
 #include "../include/oasis.h"
 #include <zlib.h>
@@ -77,7 +78,7 @@ const size_t SIZE_OF_RESULT = sizeof(Result);
 
 const unsigned int OUTPUT_STREAM_TYPE = 1;
 
-getmodel::getmodel() {
+explicit getmodel::getmodel(bool zip = false) : _zip(zip) {
   //
 }
 
@@ -263,10 +264,9 @@ int getmodel::getVulnerabilityIndex(int intensity_bin_index,
          ((damage_bin_index - 1) * _num_intensity_bins);
 }
 
-void getmodel::init(bool zip) {
-  _zip = zip;
-
+void getmodel::init() {
   getIntensityInfo();
+
 
   std::set<int> v; // set of vulnerabilities;
   getItems(v);
@@ -322,7 +322,7 @@ void getmodel::doCdfInnerz(std::list<int> &event_ids,
   auto sizeof_EventKey = sizeof(EventRow);
   auto fin = fopen(ZFOOTPRINT_FILE, "rb");
   auto intensity = std::vector<OASIS_FLOAT>(_num_intensity_bins, 0.0f);
-  for (int event_id : event_ids) {        
+  for (int event_id : event_ids) {
     bool do_cdf_for_area_peril = false;
     intensity = std::vector<OASIS_FLOAT>(_num_intensity_bins, 0.0f);
     if (event_index_by_event_id.count(event_id) == 0)
@@ -349,7 +349,7 @@ void getmodel::doCdfInnerz(std::list<int> &event_ids,
         static_cast<int>(dest_length / sizeof_EventKey);
     EventRow *event_key = (EventRow *)&_uncompressed_buf[0];
     int current_areaperil_id = -1;
-    for (int i = 0; i < number_of_event_records; i++) {      
+    for (int i = 0; i < number_of_event_records; i++) {
       if (event_key->areaperil_id != current_areaperil_id) {
         if (do_cdf_for_area_peril) {
           // Generate and write the results
@@ -363,7 +363,7 @@ void getmodel::doCdfInnerz(std::list<int> &event_ids,
       }
       if (do_cdf_for_area_peril) {
         intensity[event_key->intensity_bin_id - 1] = event_key->probability;
-      }      
+      }
       event_key++;
     }
     // Write out results for last event record
@@ -422,7 +422,7 @@ void getmodel::doCdfInner(std::list<int> &event_ids,
   fclose(fin);
 }
 
-void getmodel::doCdfInnerNoIntensityUncertaintyz(  
+void getmodel::doCdfInnerNoIntensityUncertaintyz(
     std::list<int> &event_ids,
     std::map<int, EventIndex> &event_index_by_event_id) {
   auto sizeof_EventKey = sizeof(EventRow);
@@ -441,7 +441,7 @@ void getmodel::doCdfInnerNoIntensityUncertaintyz(
     if (ret != Z_OK) {
       fprintf(stderr, "Got bad return code from uncompress %d\n", ret);
       exit(-1);
-    }    
+    }
     // we now have the data length
     int number_of_event_records =
         static_cast<int>(dest_length / sizeof_EventKey);

--- a/src/getmodel/getmodel.cpp
+++ b/src/getmodel/getmodel.cpp
@@ -133,7 +133,7 @@ void getmodel::getIntensityInfo() {
   fclose(fin);
 }
 
-auto getmodel::getItems() -> std::unique_ptr<std::set<int>> {
+auto getmodel::getItems() -> std::set<int> {
   // Read the exposures and generate a set of vulnerabilities by area peril
   item item_rec;
 
@@ -143,9 +143,7 @@ auto getmodel::getItems() -> std::unique_ptr<std::set<int>> {
     exit(EXIT_FAILURE);
   }
 
-  // C++14:
-  //auto v = std::make_unique<std::set<int>>();
-  auto v = std::unique_ptr<std::set<int>>{ new std::set<int> };
+  auto v = std::set<int>();
 
   while (fread(&item_rec, sizeof(item_rec), 1, fin) != 0) {
     if (_vulnerability_ids_by_area_peril.count(item_rec.areaperil_id) == 0)
@@ -153,11 +151,11 @@ auto getmodel::getItems() -> std::unique_ptr<std::set<int>> {
     _vulnerability_ids_by_area_peril[item_rec.areaperil_id].insert(
         item_rec.vulnerability_id);
     _area_perils.insert(item_rec.areaperil_id);
-    v->insert(item_rec.vulnerability_id);
+    v.insert(item_rec.vulnerability_id);
   }
   fclose(fin);
 
-  return v;
+  return v; // RVO or move
 }
 
 void getmodel::getDamageBinDictionary() {
@@ -272,7 +270,7 @@ int getmodel::getVulnerabilityIndex(int intensity_bin_index,
 
 void getmodel::getVulnerabilities() {
     auto v = getItems();
-    getVulnerabilities(*v);
+    getVulnerabilities(v);
 }
 
 void getmodel::init() {

--- a/src/getmodel/getmodel.h
+++ b/src/getmodel/getmodel.h
@@ -75,7 +75,7 @@ private:
     void getVulnerabilities(const std::set<int> &v);
     void getVulnerabilities();
     void getDamageBinDictionary();
-    auto getItems() -> std::unique_ptr<std::set<int>>;
+    auto getItems() -> std::set<int>;
 	void getIntensityInfo();
     void doCdfInner(std::list<int> &event_ids, std::map<int, EventIndex> &event_index_by_event_id);
     void doCdfInnerNoIntensityUncertainty(std::list<int> &event_ids, std::map<int, EventIndex> &event_index_by_event_id);

--- a/src/getmodel/getmodel.h
+++ b/src/getmodel/getmodel.h
@@ -53,33 +53,34 @@ class getmodel {
 
 public:
 
-    getmodel();
+    explicit getmodel(bool zip = false);
     ~getmodel();
-    void init(bool zip);
+    void init();
 	void doCdf(std::list<int> event_ids);
 
 private:
-	
-	std::map<int, std::vector<OASIS_FLOAT> > _vulnerabilities;	
+
+	std::map<int, std::vector<OASIS_FLOAT> > _vulnerabilities;
 	std::map<int, std::set<int> > _vulnerability_ids_by_area_peril;
 	std::set<int> _area_perils;
 	std::vector<OASIS_FLOAT> _mean_damage_bins;
     std::vector<unsigned char > _compressed_buf;
     std::vector<unsigned char > _uncompressed_buf;
-    
+
     int _num_intensity_bins = -1;
     int _num_damage_bins = -1;
     int _has_intensity_uncertainty = false;
     Result* _temp_results;
     bool _zip = false;
     void getVulnerabilities(const std::set<int> &v);
+    void getVulnerabilities();
     void getDamageBinDictionary();
-    void getItems(std::set<int> &v);
+    auto getItems() -> std::unique_ptr<std::set<int>>;
 	void getIntensityInfo();
     void doCdfInner(std::list<int> &event_ids, std::map<int, EventIndex> &event_index_by_event_id);
     void doCdfInnerNoIntensityUncertainty(std::list<int> &event_ids, std::map<int, EventIndex> &event_index_by_event_id);
     void doCdfInnerz(std::list<int> &event_ids, std::map<int, EventIndex> &event_index_by_event_id);
-    void doCdfInnerNoIntensityUncertaintyz(std::list<int> &event_ids, 
+    void doCdfInnerNoIntensityUncertaintyz(std::list<int> &event_ids,
     std::map<int, EventIndex> &event_index_by_event_id);
     void  doResults(
         int &event_id,
@@ -94,7 +95,7 @@ private:
 		std::map<int, std::set<int> > &vulnerabilities_by_area_peril,
 		std::map<int, std::vector<OASIS_FLOAT> > &vulnerabilities,
 		int intensity_bin_index) const;
-	
+
 	static void initOutputStream();
     int getVulnerabilityIndex(int intensity_bin_index, int damage_bin_index) const;
 };

--- a/src/getmodel/main.cpp
+++ b/src/getmodel/main.cpp
@@ -61,9 +61,9 @@ void help()
 void doIt(bool zip)
 {
 
-	getmodel cdf_generator;
+	getmodel cdf_generator{ zip };
 
-	cdf_generator.init(zip);
+	cdf_generator.init();
 
 	int event_id = -1;
 	std::list<int> event_ids;
@@ -78,7 +78,7 @@ void doIt(bool zip)
 
 int main(int argc, char** argv)
 {
-	int opt;	
+	int opt;
 	while ((opt = getopt(argc, argv, "vh")) != -1) {
 		switch (opt) {
 		case 'v':


### PR DESCRIPTION
While reviewing your code to understand the model I spent little time to get through:

```cpp
void getmodel::init(bool zip) {
  _zip = zip;

  getIntensityInfo();

  std::set<int> v; // set of vulnerabilities;
  getItems(v);
  getVulnerabilities(v);
  v.clear(); // set no longer required release memory
  // ...
```

My intuitive questions were:
- Why `_zip` initialization is not in c-tor?
- Why `v` is passed to `getItems` where it seems more like a returned set built by the function?

Therefore, I wanted to reply on my own without impacting performance (i.e. not to copy the set several times). I also wanted to play with smart pointers :o).

This PR is my own answer. Let me know what you think about it. Thank you.

**cons**
- I don't visually like the call with `*v`:
    ```cpp
    auto v = getItems();
    getVulnerabilities(*v);
    ```
- I have to get used to strange modern C++ declaration:
    ```cpp
    auto getmodel::getItems() -> std::unique_ptr<std::set<int>>;
    ```
    this could be replaced by:
    ```cpp
    std::unique_ptr<std::set<int>> getmodel::getItems();
    ```

**pros**
- I think it is safer and more modern C++.