### PR TITLE
Introduce period number check for option 2 format

### DIFF
--- a/src/occurrencetobin/occurrencetobin.cpp
+++ b/src/occurrencetobin/occurrencetobin.cpp
@@ -94,7 +94,11 @@ void no_occ_doit()
 			return;
 		}
 		else
-		{			
+		{
+			if(number_of_periods_ < p.period_no) {
+				fprintf(stderr, "Period number exceeds maximum supplied\n");
+				exit(EXIT_FAILURE);
+			}
 			fwrite(&p, sizeof(p), 1, stdout);
 		}
 		lineno++;


### PR DESCRIPTION
Returns error and exits when the total number of periods of event occurrences in input file exceeds that stated in command line argument. This check existed for option 1 format. Introduction of this check for option 2 format.