### PR TITLE
Feature/explicit footprint files

### DIFF
--- a/src/footprinttobin/footprinttobin.cpp
+++ b/src/footprinttobin/footprinttobin.cpp
@@ -48,9 +48,9 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #include "../include/oasis.h"
 
 namespace footprinttobin {
-	void doitz(int intensity_bins, int hasIntensityUncertainty) {
-		FILE *foutx = fopen("footprint.bin.z", "wb");
-		FILE *fouty = fopen("footprint.idx.z", "wb");
+	void doitz(int intensity_bins, int hasIntensityUncertainty, const char * binFileName="footprint.bin.z", const char * idxFileName="footprint.idx.z") {
+		FILE *foutx = fopen(binFileName, "wb");
+		FILE *fouty = fopen(idxFileName, "wb");
 
 		char line[4096];
 		int lineno = 0;
@@ -151,9 +151,9 @@ namespace footprinttobin {
 		fclose(fouty);
 	}
 
-	void doit(int intensity_bins, int hasIntensityUncertainty, bool skipheader){
-		FILE *foutx = fopen("footprint.bin", "wb");
-		FILE *fouty = fopen("footprint.idx", "wb");
+	void doit(int intensity_bins, int hasIntensityUncertainty, bool skipheader, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx"){
+		FILE *foutx = fopen(binFileName, "wb");
+		FILE *fouty = fopen(idxFileName, "wb");
 
 		char line[4096];
 		int lineno = 0;

--- a/src/footprinttobin/main.cpp
+++ b/src/footprinttobin/main.cpp
@@ -46,8 +46,8 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #endif
 
 namespace footprinttobin {
-	void doit(int intensity_bins, int hasIntensityUncertainty, bool skipheader);
-	void doitz(int intensity_bins, int hasIntensityUncertainty);
+	void doit(int intensity_bins, int hasIntensityUncertainty, bool skipheader, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx");
+	void doitz(int intensity_bins, int hasIntensityUncertainty, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx");
 }
 
 #include "../include/oasis.h"
@@ -72,7 +72,9 @@ void help() {
 	fprintf(stderr, "-i max intensity bins\n"
 		"-n No intensity uncertainty\n"
 		"-s skip header\n"
+		"-o output bin file name\n"
 		"-v version\n"
+		"-x output idx file name\n"
 		"-z zip footprint data\n"
 	);
 }
@@ -83,8 +85,12 @@ int main(int argc, char *argv[]) {
 	int intensity_bins = -1;
 	int hasIntensityUncertainty = true;
 	bool skipheader = false;
+	char *binFileName;
+	bool binFileGiven = false;
+	char *idxFileName;
+	bool idxFileGiven = false;
 	progname = argv[0];
-	while ((opt = getopt(argc, argv, "zvshni:")) != -1) {
+	while ((opt = getopt(argc, argv, "zvshni:o:x:")) != -1) {
 		switch (opt) {
 		case 'v':
 			fprintf(stderr, "%s : version: %s\n", argv[0], VERSION);
@@ -96,8 +102,16 @@ int main(int argc, char *argv[]) {
 		case 'n':
 			hasIntensityUncertainty = false;
 			break;
+		case 'o':
+			binFileGiven = true;
+			binFileName = optarg;
+			break;
 		case 's':
 			skipheader = true;
+			break;
+		case 'x':
+			idxFileGiven = true;
+			idxFileName = optarg;
 			break;
 		case 'z':
 			zip = true;
@@ -125,11 +139,27 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "Zip not supported in Microsoft build\n");
 		exit(-1);
 #else
-		footprinttobin::doitz(intensity_bins, hasIntensityUncertainty);
+		if(binFileGiven && idxFileGiven) {
+			footprinttobin::doitz(intensity_bins, hasIntensityUncertainty, binFileName, idxFileName);
+		} else if(binFileGiven || idxFileGiven) {
+			fprintf(stderr, "Must specify both bin and idx file names\n");
+			fprintf(stderr, "aborted\n");
+			exit(EXIT_FAILURE);
+		} else {
+			footprinttobin::doitz(intensity_bins, hasIntensityUncertainty);
+		}
 #endif
 	}
 	else {
-		footprinttobin::doit(intensity_bins,hasIntensityUncertainty,skipheader);
+		if(binFileGiven && idxFileGiven) {
+			footprinttobin::doit(intensity_bins, hasIntensityUncertainty, skipheader, binFileName, idxFileName);
+		} else if(binFileGiven || idxFileGiven) {
+			fprintf(stderr, "Must specify both bin and idx file names\n");
+			fprintf(stderr, "aborted\n");
+			exit(EXIT_FAILURE);
+		} else {
+			footprinttobin::doit(intensity_bins, hasIntensityUncertainty, skipheader);
+		}
 	}
 
 	fprintf(stderr, "done...\n");

--- a/src/footprinttobin/main.cpp
+++ b/src/footprinttobin/main.cpp
@@ -72,9 +72,9 @@ void help() {
 	fprintf(stderr, "-i max intensity bins\n"
 		"-n No intensity uncertainty\n"
 		"-s skip header\n"
-		"-o output bin file name\n"
 		"-v version\n"
-		"-x output idx file name\n"
+		"-b [FILE NAME] output bin file name\n"
+		"-x [FILE NAME] output idx file name\n"
 		"-z zip footprint data\n"
 	);
 }
@@ -90,21 +90,21 @@ int main(int argc, char *argv[]) {
 	char *idxFileName;
 	bool idxFileGiven = false;
 	progname = argv[0];
-	while ((opt = getopt(argc, argv, "zvshni:o:x:")) != -1) {
+	while ((opt = getopt(argc, argv, "zvshni:b:x:")) != -1) {
 		switch (opt) {
 		case 'v':
 			fprintf(stderr, "%s : version: %s\n", argv[0], VERSION);
 			exit(EXIT_FAILURE);
+			break;
+		case 'b':
+			binFileGiven = true;
+			binFileName = optarg;
 			break;
 		case 'i':
 			intensity_bins = atoi(optarg);
 			break;
 		case 'n':
 			hasIntensityUncertainty = false;
-			break;
-		case 'o':
-			binFileGiven = true;
-			binFileName = optarg;
 			break;
 		case 's':
 			skipheader = true;

--- a/src/footprinttocsv/footprinttocsv.cpp
+++ b/src/footprinttocsv/footprinttocsv.cpp
@@ -101,11 +101,11 @@ namespace footprinttocsv {
 
 
 
-	void doitz(bool skipheader,int from_event,int to_event)
+	void doitz(bool skipheader, int from_event, int to_event, const char * binFileName="footprint.bin.z", const char * idxFileName="footprint.idx.z")
 	{
 		if (skipheader == false)  printf("event_id, areaperil_id, intensity_bin_id, probability\n");
-		FILE *finx = fopen("footprint.bin.z", "rb");
-		FILE *finy = fopen("footprint.idx.z", "rb");
+		FILE *finx = fopen(binFileName, "rb");
+		FILE *finy = fopen(idxFileName, "rb");
 		EventIndex current_idx;
 		EventIndex next_idx;
 
@@ -137,11 +137,11 @@ namespace footprinttocsv {
 		fclose(finy);
 	}
 
-	void doit(bool skipheader,int from_event, int to_event)
+	void doit(bool skipheader, int from_event, int to_event, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx")
 	{
 		if (skipheader == false)  printf("event_id, areaperil_id, intensity_bin_id, probability\n");
-		FILE *finx = fopen("footprint.bin", "rb");
-		FILE *finy = fopen("footprint.idx", "rb");
+		FILE *finx = fopen(binFileName, "rb");
+		FILE *finy = fopen(idxFileName, "rb");
 
 		EventIndex idx;
 

--- a/src/footprinttocsv/main.cpp
+++ b/src/footprinttocsv/main.cpp
@@ -53,8 +53,8 @@ Author: Joh Carter  email: johanna.carter@oasislmf.org
 
 
 namespace footprinttocsv {
-	void doit(bool skipheader, int from_event, int to_event);
-	void doitz(bool skipheader,int from_event, int to_event);
+	void doit(bool skipheader, int from_event, int to_event, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx");
+	void doitz(bool skipheader,int from_event, int to_event, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx");
 }
 
 #include "../include/oasis.h"
@@ -86,7 +86,11 @@ int main(int argc, char* argv[])
 	bool zip = false;
 	int from_event = 1;
 	int to_event = 999999999;
-	while ((opt = getopt(argc, argv, "e:zvhs")) != -1) {
+	char *binFileName;
+	bool binFileGiven = false;
+	char *idxFileName;
+	bool idxFileGiven = false;
+	while ((opt = getopt(argc, argv, "e:zvhsb:x:")) != -1) {
 		switch (opt) {
 		case 'v':
 			fprintf(stderr, "%s : version: %s\n", argv[0], VERSION);
@@ -123,6 +127,14 @@ int main(int argc, char* argv[])
 		case 's':
 			skipheader = true;
 			break;
+		case 'b':
+			binFileGiven = true;
+			binFileName = optarg;
+			break;
+		case 'x':
+			idxFileGiven = true;
+			idxFileName = optarg;
+			break;
 		case 'h':
 			help();
 			exit(EXIT_FAILURE);
@@ -143,10 +155,24 @@ int main(int argc, char* argv[])
 	try {
 		initstreams();
 		if (zip) {
-			footprinttocsv::doitz(skipheader,from_event,to_event);
+			if(binFileGiven && idxFileGiven) {
+				footprinttocsv::doitz(skipheader, from_event, to_event, binFileName, idxFileName);
+			} else if(binFileGiven || idxFileGiven) {
+				fprintf(stderr, "Must specify both bin and idx file names\n");
+				exit(EXIT_FAILURE);
+			} else {
+				footprinttocsv::doitz(skipheader, from_event, to_event);
+			}
 		}
 		else {
-			footprinttocsv::doit(skipheader,from_event, to_event);
+			if(binFileGiven && idxFileGiven) {
+				footprinttocsv::doit(skipheader, from_event, to_event, binFileName, idxFileName);
+			} else if(binFileGiven || idxFileGiven) {
+				fprintf(stderr, "Must specify both bin and idx file names\n");
+				exit(EXIT_FAILURE);
+			} else {
+				footprinttocsv::doit(skipheader, from_event, to_event);
+			}
 		}
 	}
 	catch (std::bad_alloc) {

--- a/src/footprinttocsv/main.cpp
+++ b/src/footprinttocsv/main.cpp
@@ -75,6 +75,8 @@ void help()
 		"-v version\n"
 		"-z zip input\n"
 		"-e [event_id from]-[event_id to] extract an inclusive range of events\n"
+		"-b [FILE NAME] input bin file name\n"
+		"-x [FILE NAME] input idx file name\n"
 		"-h help\n"
 	);
 }


### PR DESCRIPTION
With reference to https://github.com/OasisLMF/ktools/issues/65 , output `bin` and `idx` files can be explicitly set when executing `footprinttobin` with the `-b` and `-x` flags respectively:

```footprinttobin -i [intensity bins] -b footprint_2.bin -x footprint_2.idx < footprint.csv``` will convert `footprint.csv` to `footprint_2.bin` and `footprint_2.idx`.

```footprinttobin -i [intensity bins] -b footprint_2.bin < footprint.csv``` or ```footprint -i [intensity bins] -x footprint_2.idx < footprint.csv``` will yield an error message stating that both output files must be given.

```footprinttobin -i [intensity bins] < footprint.csv``` will convert `footprint.csv` to `footprint.bin` and `footprint.idx` (i.e. the current behaviour).

Similarly, when executing `footprinttocsv`:

```footprinttocsv -b footprint_2.bin -x footprint_2.idx > footprint.csv``` will convert `footprint_2.bin` and `footprint_2.idx` to `footprint.csv`.

```footprinttocsv -b footprint_2.bin > footprint.csv``` or ```footprinttocsv -x footprint_2.idx> footprint.csv``` will yield an error message stating that both input files must be given.

```footprinttocsv > footprint.csv``` will convert `footprint.bin` and `footprint.idx` to `footprint.csv` (i.e. the current behaviour).