### PR TITLE
Move fm_policyTC struct to common header file

### DIFF
--- a/src/fmcalc/fmcalc.h
+++ b/src/fmcalc/fmcalc.h
@@ -44,13 +44,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #include <vector>
 #include <map>
 
-struct fm_policyTC {
-	int level_id;
-	int agg_id;
-	int layer_id;
-	int profile_id;			// for some strange reason historically this has been named PolicyTC_id it really is the unique identifier of the profile table so I've renamed it!!
-};
-
 
 class fmcalc {
 public:	

--- a/src/fmpolicytctobin/fmpolicytctobin.cpp
+++ b/src/fmpolicytctobin/fmpolicytctobin.cpp
@@ -46,13 +46,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #include <unistd.h>
 #endif
 
-
-struct fm_policyTC {
-  int level_id;
-  int agg_id;
-  int layer_id;
-  int profile_id;			// for some strange reason historically this has been named PolicyTC_id it really is the unique identifier of the profile table so I've renamed it!!
-};
 namespace fmpolicytctobin {
 	void doit()
 	{

--- a/src/fmpolicytctocsv/fmpolicytctocsv.cpp
+++ b/src/fmpolicytctocsv/fmpolicytctocsv.cpp
@@ -51,13 +51,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 
 using namespace std;
 
-struct fm_policyTC {
-	int level_id;
-	int agg_id;
-	int layer_id;
-	int profile_id;			// for some strange reason historically this has been named PolicyTC_id it really is the unique identifier of the profile table so I've renamed it!!
-};
-
 namespace fmpolicytctocsv {
 	void doit(bool skipheader)
 	{

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -192,6 +192,12 @@ struct fmsummaryxref {
 	int summaryset_id;
 };
 
+struct fm_policyTC {
+        int level_id;
+        int agg_id;
+        int layer_id;
+        int profile_id;                 // for some strange reason historically this has been named PolicyTC_id it really is the unique identifier of the profile table so I've renamed it!!
+};
 
 struct fm_profile {
 	int profile_id = 0;


### PR DESCRIPTION
fm_policyTC struct definition moved to `include/oasis.h`, and removed from individual source files.