### PR TITLE
Fix gulcalc stream headers

### DIFF
--- a/src/gulcalc/doit.cpp
+++ b/src/gulcalc/doit.cpp
@@ -158,23 +158,25 @@ void doit(const gulcalcopts &opt)
 
 	void(*itmWriter)(const void *ibuf, int size, int count);
 	void(*covWriter)(const void *ibuf, int size, int count);
-    void (*lossWriter)(const void *ibuf, int size, int count);
-    void(*corrWriter)(const void *ibuf, int size, int count);
+    	void (*lossWriter)(const void *ibuf, int size, int count);
+    	void(*corrWriter)(const void *ibuf, int size, int count);
 
 	itmWriter = 0;
 	covWriter = 0;
-    lossWriter = 0;
-    corrWriter = 0;
+    	lossWriter = 0;
+    	corrWriter = 0;
 
 	getRands rnd(opt.rndopt, opt.rand_vector_size, opt.rand_seed);
 	getRands rnd0(opt.rndopt, opt.rand_vector_size, opt.rand_seed);
 	itemout = opt.itemout;
 	covout = opt.covout;
 	corrout = opt.corrout;
-	if (opt.itemLevelOutput == true && opt.mode == 0) itmWriter = itemWriter;
+	if (opt.itemLevelOutput == true) {
+		if (opt.allocRule == 0 || opt.allocRule == 1) lossWriter = itemWriter;   // If alloc rule has been specified
+		else if (opt.mode == 0) itmWriter = itemWriter;
+	}
 	if (opt.coverageLevelOutput == true) covWriter = coverageWriter;
-    if (opt.itemLevelOutput == true && opt.mode == 1) lossWriter = itemWriter;
-    if(opt.correlatedLevelOutput == true) corrWriter = correlatedWriter;
+    	if(opt.correlatedLevelOutput == true) corrWriter = correlatedWriter;
 	gulcalc g(damagebindictionary_vec, coverages, item_map, rnd, rnd0,   itmWriter, covWriter,lossWriter, corrWriter, iGetrec,opt);
 	if (opt.mode == 0) g.mode0();		// classic gulcalc
 	if (opt.mode == 1) g.mode1();		// first type of back allocation

--- a/src/gulcalc/gulcalc.h
+++ b/src/gulcalc/gulcalc.h
@@ -100,7 +100,8 @@ struct gulcalcopts {
 	FILE *itemout = stdout;
 	FILE *covout = stdout;
 	FILE *corrout = stdout;
-	int mode = 0;		// default mode = 0 
+	int mode = 0;		// default mode = 0
+	int allocRule = -1;   // default is unset
 };
 
 struct gulItemIDLoss {

--- a/src/gulcalc/main.cpp
+++ b/src/gulcalc/main.cpp
@@ -100,7 +100,8 @@ int main(int argc, char *argv[])
 			gopt.rndopt = rd_option::usehashedseed;
 			break;
 		case 'a':
-			gopt.mode = atoi(optarg);	// alloc rule and mode are the same thing
+			gopt.allocRule = atoi(optarg);
+			gopt.mode = gopt.allocRule;   // set mode to alloc rule
 			break;
 		case 'r':
 			gopt.rndopt = rd_option::userandomnumberfile;


### PR DESCRIPTION
Added `int allocRule = -1` to `gulcalopts` struct. Should alloc rule be specified on command line as either 0 or 1, loss stream is used. If alloc rule is not specified on command line (i.e. default value of -1), then item stream is used.

Now see the following output with first 4 bytes showing correct values for loss stream:

```
# eve 1 240 | getmodel | gulcalc -S50 -L0 -a0 -i - | hexdump | head -1
0000000 0001 0200 0032 0000 e39f 03b5 8365 0000
```