### PR TITLE
Check for areaperil_id data type in validation executables

### DIFF
--- a/src/crossvalidation/crossvalidation.cpp
+++ b/src/crossvalidation/crossvalidation.cpp
@@ -128,8 +128,13 @@ namespace crossvalidation {
     lineno++;
     while(fgets(line, sizeof(line), footprintFile) != 0) {
 
-      if(sscanf(line, "%d,%d,%d,%f", &f.event_id, &f.areaperil_id,
+#ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+      if(sscanf(line, "%d,%llu,%d,%f", &f.event_id, &f.areaperil_id,
 		&f.intensity_bin_id, &f.probability) != 4) {
+#else
+      if(sscanf(line, "%d,%u,%d,%f", &f.event_id, &f.areaperil_id,
+		&f.intensity_bin_id, &f.probability) != 4) {
+#endif
 
 	fprintf(stderr, "File %s\n", footprintFileName);
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);

--- a/src/validatefootprint/validatefootprint.cpp
+++ b/src/validatefootprint/validatefootprint.cpp
@@ -30,7 +30,11 @@ namespace validatefootprint {
   inline bool ProbabilityError(FootprintRow r, float prob) {
   
     fprintf(stderr, "Probabilities for event ID %d", r.event_id);
-    fprintf(stderr, " and areaperil ID %d", r.areaperil_id);
+#ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+    fprintf(stderr, " and areaperil ID %llu", r.areaperil_id);
+#else
+    fprintf(stderr, " and areaperil ID %u", r.areaperil_id);
+#endif
     fprintf(stderr, " do not sum to 1.\n");
     fprintf(stderr, "Probability = %f\n", prob);
     
@@ -59,8 +63,14 @@ namespace validatefootprint {
     char const * sAreaperil = "Areaperil";
     float prob = 0.0;
     char prevLine[4096], line[4096];
-    sprintf(prevLine, "%d, %d, %d, %f", p.event_id, p.areaperil_id,
+
+#ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+    sprintf(prevLine, "%d, %llu, %d, %f", p.event_id, p.areaperil_id,
 	    p.intensity_bin_id, p.probability);
+#else
+    sprintf(prevLine, "%d, %u, %d, %f", p.event_id, p.areaperil_id,
+	    p.intensity_bin_id, p.probability);
+#endif
     int lineno = 0;
     fgets(line, sizeof(line), stdin);   // Skip header line
     lineno++;
@@ -68,8 +78,13 @@ namespace validatefootprint {
     while(fgets(line, sizeof(line), stdin) != 0) {
 
       // Check for invalid data
-      if(sscanf(line, "%d,%d,%d,%f", &q.event_id, &q.areaperil_id,
+#ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+      if(sscanf(line, "%d,%llu,%d,%f", &q.event_id, &q.areaperil_id,
 		&q.intensity_bin_id, &q.probability) != 4) {
+#else
+      if(sscanf(line, "%d,%u,%d,%f", &q.event_id, &q.areaperil_id,
+		&q.intensity_bin_id, &q.probability) != 4) {
+#endif
 
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);
 	dataValid = false;

--- a/src/validateoasisfiles/validateoasisfiles.cpp
+++ b/src/validateoasisfiles/validateoasisfiles.cpp
@@ -190,8 +190,13 @@ namespace validateoasisfiles {
     lineno++;
     while(fgets(line, sizeof(line), itemsFile) != 0) {
 
+#ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+      if(sscanf(line, "%d,%d,%llu,%d,%d", &q.id, &q.coverage_id,
+		&q.areaperil_id, &q.vulnerability_id, &q.group_id) != 5) {
+#else
       if(sscanf(line, "%d,%d,%d,%d,%d", &q.id, &q.coverage_id, &q.areaperil_id,
 		&q.vulnerability_id, &q.group_id) != 5) {
+#endif
 
 	fprintf(stderr, "File %s\n", itemsPath);
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);


### PR DESCRIPTION
Re: issue https://github.com/OasisLMF/ktools/issues/112, `areaperil_id` appears to be the problem as this can be either an `unsigned int` or `unsigned long long` depending on a preprocessor directive (`AREAPERIL_TYPE_UNSIGNED_LONG_LONG` in `include/oasis.h`) at compilation time. Introduce conditional statements to alter behaviour in validation executables depending on `areaperil_id` data type.