### PR TITLE
Updates to the CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,16 @@
 cmake_minimum_required(VERSION 3.13)
-project(ktools)
+
+set(PROJECT_NAME ktools)
+
+project(${PROJECT_NAME})
 
 # Create the VERSION define
-set(KTOOLS_VERSION "3.1.0")
-configure_file(config.h.cmake_in config.h)
+file(READ "${CMAKE_SOURCE_DIR}/VERSION.in" KTOOLS_VERSION)
+string(REGEX MATCH "([0-9]\.[0-9]\.[0-9])" _ ${KTOOLS_VERSION})
+set(KTOOLS_VERSION ${CMAKE_MATCH_1})
+
+# Should not be done, but it is to maintain compatibility with the autotools build
+configure_file(config.h.cmake_in ${CMAKE_SOURCE_DIR}/config.h)
 
 ENABLE_TESTING()
 
@@ -30,7 +37,13 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 endif()
 
 
-add_test(ktest ./ktest/runtests.sh)
-add_test(ktest-extended ./ktest/runtestsx.sh)
-
 add_subdirectory(src)
+
+file(COPY ${CMAKE_SOURCE_DIR}/ktest DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${CMAKE_SOURCE_DIR}/examples DESTINATION ${CMAKE_BINARY_DIR})
+
+include(CTest) 
+add_test(ktest ${CMAKE_BINARY_DIR}/ktest/runtests.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/ktest)
+add_test(ktest-extended ${CMAKE_BINARY_DIR}/ktest/runtestsx.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/ktest)
+
+

--- a/README.md
+++ b/README.md
@@ -80,16 +80,21 @@ Follow the rest of the process as described above.
 
 ### Cmake build - Experimental 
 
-Install Cmake from either system packages or [cmake.org](https://cmake.org/download/)
+Install Cmake from either system packages or [cmake.org](https://cmake.org/download/).
 
 ``` sh
-$ cmake .
-```
+# create the build directory within ktools directory
+$ mkdir build && cd build
+$ ktools_source_dir=~/ktools
+# Generate files and specify destination (here is in ./local/bin)
+$ cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/.local $ktools_source_dir
 
-``` sh
+# Build
 $ make all test
-```
 
+# If all is OK, install to bin subdir of the specified install prefix
+$ make install
+```
 
 ## Windows Installation
 

--- a/src/aalcalc/CMakeLists.txt
+++ b/src/aalcalc/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(aalcalc
 if (WIN32)
 	target_link_libraries(aalcalc wingetopt)
 endif()
+
+install(TARGETS aalcalc RUNTIME DESTINATION bin)

--- a/src/aalcalctocsv/CMakeLists.txt
+++ b/src/aalcalctocsv/CMakeLists.txt
@@ -1,3 +1,4 @@
+set (target aalcalc)
 add_executable(aalcalctocsv)
 target_sources(aalcalctocsv
 	PRIVATE
@@ -7,3 +8,5 @@ target_sources(aalcalctocsv
 if (WIN32)
 	target_link_libraries(aalcalctocsv wingetopt)
 endif()
+
+install(TARGETS aalcalctocsv RUNTIME DESTINATION bin)

--- a/src/cdftocsv/CMakeLists.txt
+++ b/src/cdftocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(cdftocsv
 if (WIN32)
 	target_link_libraries(cdftocsv wingetopt)
 endif()
+
+install(TARGETS cdftocsv RUNTIME DESTINATION bin)

--- a/src/coveragetobin/CMakeLists.txt
+++ b/src/coveragetobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(coveragetobin
 if (WIN32)
 	target_link_libraries(coveragetobin wingetopt)
 endif()
+
+install(TARGETS coveragetobin RUNTIME DESTINATION bin)

--- a/src/coveragetocsv/CMakeLists.txt
+++ b/src/coveragetocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(coveragetocsv
 if (WIN32)
 	target_link_libraries(coveragetocsv wingetopt)
 endif()
+
+install(TARGETS coveragetocsv RUNTIME DESTINATION bin)

--- a/src/crossvalidation/CMakeLists.txt
+++ b/src/crossvalidation/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(crossvalidation)
+target_sources(crossvalidation
+	PRIVATE
+		crossvalidation.cpp main.cpp
+)
+
+if (WIN32)
+	target_link_libraries(crossvalidation wingetopt)
+endif()
+
+install(TARGETS crossvalidation RUNTIME DESTINATION bin)

--- a/src/damagebintobin/CMakeLists.txt
+++ b/src/damagebintobin/CMakeLists.txt
@@ -6,3 +6,4 @@ target_sources(damagebintobin
 if (WIN32)
 	target_link_libraries(damagebintobin wingetopt)
 endif()
+install(TARGETS damagebintobin RUNTIME DESTINATION bin)

--- a/src/damagebintocsv/CMakeLists.txt
+++ b/src/damagebintocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(damagebintocsv
 if (WIN32)
 	target_link_libraries(damagebintocsv wingetopt)
 endif()
+
+install(TARGETS damagebintocsv RUNTIME DESTINATION bin)

--- a/src/eltcalc/CMakeLists.txt
+++ b/src/eltcalc/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(eltcalc
 if (WIN32)
 	target_link_libraries(eltcalc wingetopt)
 endif()
+
+install(TARGETS eltcalc RUNTIME DESTINATION bin)

--- a/src/eve/CMakeLists.txt
+++ b/src/eve/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(eve
 if (WIN32)
 	target_link_libraries(eve wingetopt)
 endif()
+
+install(TARGETS eve RUNTIME DESTINATION bin)

--- a/src/evetobin/CMakeLists.txt
+++ b/src/evetobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(evetobin
 if (WIN32)
 	target_link_libraries(evetobin wingetopt)
 endif()
+
+install(TARGETS evetobin RUNTIME DESTINATION bin)

--- a/src/evetocsv/CMakeLists.txt
+++ b/src/evetocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(evetocsv
 if (WIN32)
 	target_link_libraries(evetocsv wingetopt)
 endif()
+
+install(TARGETS evetocsv RUNTIME DESTINATION bin)

--- a/src/fmcalc/CMakeLists.txt
+++ b/src/fmcalc/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmcalc
 if (WIN32)
 	target_link_libraries(fmcalc wingetopt)
 endif()
+
+install(TARGETS fmcalc RUNTIME DESTINATION bin)

--- a/src/fmpolicytctobin/CMakeLists.txt
+++ b/src/fmpolicytctobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmpolicytctobin
 if (WIN32)
 	target_link_libraries(fmpolicytctobin wingetopt)
 endif()
+
+install(TARGETS fmpolicytctobin RUNTIME DESTINATION bin)

--- a/src/fmpolicytctocsv/CMakeLists.txt
+++ b/src/fmpolicytctocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmpolicytctocsv
 if (WIN32)
 	target_link_libraries(fmpolicytctocsv wingetopt)
 endif()
+
+install(TARGETS fmpolicytctocsv RUNTIME DESTINATION bin)

--- a/src/fmprofilebinconv/CMakeLists.txt
+++ b/src/fmprofilebinconv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmprofilebinconv
 if (WIN32)
 	target_link_libraries(fmprofilebinconv wingetopt)
 endif()
+
+install(TARGETS fmprofilebinconv RUNTIME DESTINATION bin)

--- a/src/fmprofiletobin/CMakeLists.txt
+++ b/src/fmprofiletobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmprofiletobin
 if (WIN32)
 	target_link_libraries(fmprofiletobin wingetopt)
 endif()
+
+install(TARGETS fmprofiletobin RUNTIME DESTINATION bin)

--- a/src/fmprofiletocsv/CMakeLists.txt
+++ b/src/fmprofiletocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmprofiletocsv
 if (WIN32)
 	target_link_libraries(fmprofiletocsv wingetopt)
 endif()
+
+install(TARGETS fmprofiletocsv RUNTIME DESTINATION bin)

--- a/src/fmprogrammetobin/CMakeLists.txt
+++ b/src/fmprogrammetobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmprogrammetobin
 if (WIN32)
 	target_link_libraries(fmprogrammetobin wingetopt)
 endif()
+
+install(TARGETS fmprogrammetobin RUNTIME DESTINATION bin)

--- a/src/fmprogrammetocsv/CMakeLists.txt
+++ b/src/fmprogrammetocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmprogrammetocsv
 if (WIN32)
 	target_link_libraries(fmprogrammetocsv wingetopt)
 endif()
+
+install(TARGETS fmprogrammetocsv RUNTIME DESTINATION bin)

--- a/src/fmsummaryxreftobin/CMakeLists.txt
+++ b/src/fmsummaryxreftobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmsummaryxreftobin
 if (WIN32)
 	target_link_libraries(fmsummaryxreftobin wingetopt)
 endif()
+
+install(TARGETS fmsummaryxreftobin RUNTIME DESTINATION bin)

--- a/src/fmsummaryxreftocsv/CMakeLists.txt
+++ b/src/fmsummaryxreftocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmsummaryxreftocsv
 if (WIN32)
 	target_link_libraries(fmsummaryxreftocsv wingetopt)
 endif()
+
+install(TARGETS fmsummaryxreftocsv RUNTIME DESTINATION bin)

--- a/src/fmtocsv/CMakeLists.txt
+++ b/src/fmtocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmtocsv
 if (WIN32)
 	target_link_libraries(fmtocsv wingetopt)
 endif()
+
+install(TARGETS fmtocsv RUNTIME DESTINATION bin)

--- a/src/fmxreftobin/CMakeLists.txt
+++ b/src/fmxreftobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmxreftobin
 if (WIN32)
 	target_link_libraries(fmxreftobin wingetopt)
 endif()
+
+install(TARGETS fmxreftobin RUNTIME DESTINATION bin)

--- a/src/fmxreftocsv/CMakeLists.txt
+++ b/src/fmxreftocsv/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(fmxreftocsv
 if (WIN32)
 	target_link_libraries(fmxreftocsv wingetopt)
 endif()
+
+install(TARGETS fmxreftocsv RUNTIME DESTINATION bin)

--- a/src/footprintconv/CMakeLists.txt
+++ b/src/footprintconv/CMakeLists.txt
@@ -5,3 +5,5 @@ target_sources(footprintconv
 )
 
 target_link_libraries(footprintconv ${ZLIB_LIBRARIES})
+
+install(TARGETS footprintconv RUNTIME DESTINATION bin)

--- a/src/footprinttobin/CMakeLists.txt
+++ b/src/footprinttobin/CMakeLists.txt
@@ -8,3 +8,5 @@ target_link_libraries(footprinttobin ${ZLIB_LIBRARIES})
 if (WIN32)
 	target_link_libraries(footprinttobin wingetopt ${ZLIB_LIBRARIES})
 endif()
+
+install(TARGETS footprinttobin RUNTIME DESTINATION bin)

--- a/src/footprinttocsv/CMakeLists.txt
+++ b/src/footprinttocsv/CMakeLists.txt
@@ -8,3 +8,5 @@ target_link_libraries(footprinttocsv ${ZLIB_LIBRARIES})
 if (WIN32)
 	target_link_libraries(footprinttocsv wingetopt ${ZLIB_LIBRARIES})
 endif()
+
+install(TARGETS footprinttocsv RUNTIME DESTINATION bin)

--- a/src/getmodel/CMakeLists.txt
+++ b/src/getmodel/CMakeLists.txt
@@ -8,3 +8,5 @@ target_link_libraries(getmodel ${ZLIB_LIBRARIES})
 if (WIN32)
 	target_link_libraries(getmodel wingetopt ${ZLIB_LIBRARIES})
 endif()
+
+install(TARGETS getmodel RUNTIME DESTINATION bin)

--- a/src/gulcalc/CMakeLists.txt
+++ b/src/gulcalc/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(gulcalc
 if (WIN32)
 	target_link_libraries(gulcalc wingetopt)
 endif()
+
+install(TARGETS gulcalc RUNTIME DESTINATION bin)

--- a/src/gulsummaryxreftobin/CMakeLists.txt
+++ b/src/gulsummaryxreftobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(gulsummaryxreftobin
 if (WIN32)
 	target_link_libraries(gulsummaryxreftobin wingetopt)
 endif()
+
+install(TARGETS gulsummaryxreftobin RUNTIME DESTINATION bin)

--- a/src/gulsummaryxreftocsv/CMakeLists.txt
+++ b/src/gulsummaryxreftocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(gulsummaryxreftocsv
 if (WIN32)
 	target_link_libraries(gulsummaryxreftocsv wingetopt)
 endif()
+
+install(TARGETS gulsummaryxreftocsv RUNTIME DESTINATION bin)

--- a/src/gultobin/CMakeLists.txt
+++ b/src/gultobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(gultobin
 if (WIN32)
 	target_link_libraries(gultobin wingetopt)
 endif()
+
+install(TARGETS gultobin RUNTIME DESTINATION bin)

--- a/src/gultocsv/CMakeLists.txt
+++ b/src/gultocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(gultocsv
 if (WIN32)
 	target_link_libraries(gultocsv wingetopt)
 endif()
+
+install(TARGETS gultocsv RUNTIME DESTINATION bin)

--- a/src/itemtobin/CMakeLists.txt
+++ b/src/itemtobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(itemtobin
 if (WIN32)
 	target_link_libraries(itemtobin wingetopt)
 endif()
+
+install(TARGETS itemtobin RUNTIME DESTINATION bin)

--- a/src/itemtocsv/CMakeLists.txt
+++ b/src/itemtocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(itemtocsv
 if (WIN32)
 	target_link_libraries(itemtocsv wingetopt)
 endif()
+
+install(TARGETS itemtocsv RUNTIME DESTINATION bin)

--- a/src/kat/CMakeLists.txt
+++ b/src/kat/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(kat
 if (WIN32)
 	target_link_libraries(kat wingetopt)
 endif()
+
+install(TARGETS kat RUNTIME DESTINATION bin)

--- a/src/kunit/CMakeLists.txt
+++ b/src/kunit/CMakeLists.txt
@@ -5,3 +5,5 @@ target_sources(kunit
 )
 
 add_test(kunit kunit)
+
+install(TARGETS kunit RUNTIME DESTINATION bin)

--- a/src/leccalc/CMakeLists.txt
+++ b/src/leccalc/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(leccalc
 if (WIN32)
 	target_link_libraries(leccalc wingetopt)
 endif()
+
+install(TARGETS leccalc RUNTIME DESTINATION bin)

--- a/src/occurrencetobin/CMakeLists.txt
+++ b/src/occurrencetobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(occurrencetobin
 if (WIN32)
 	target_link_libraries(occurrencetobin wingetopt)
 endif()
+
+install(TARGETS occurrencetobin RUNTIME DESTINATION bin)

--- a/src/occurrencetocsv/CMakeLists.txt
+++ b/src/occurrencetocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(occurrencetocsv
 if (WIN32)
 	target_link_libraries(occurrencetocsv wingetopt)
 endif()
+
+install(TARGETS occurrencetocsv RUNTIME DESTINATION bin)

--- a/src/periodstobin/CMakeLists.txt
+++ b/src/periodstobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(periodstobin
 if (WIN32)
 	target_link_libraries(periodstobin wingetopt)
 endif()
+
+install(TARGETS periodstobin RUNTIME DESTINATION bin)

--- a/src/periodstocsv/CMakeLists.txt
+++ b/src/periodstocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(periodstocsv
 if (WIN32)
 	target_link_libraries(periodstocsv wingetopt)
 endif()
+
+install(TARGETS periodstocsv RUNTIME DESTINATION bin)

--- a/src/pltcalc/CMakeLists.txt
+++ b/src/pltcalc/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(pltcalc
 if (WIN32)
 	target_link_libraries(pltcalc wingetopt)
 endif()
+
+install(TARGETS pltcalc RUNTIME DESTINATION bin)

--- a/src/randtobin/CMakeLists.txt
+++ b/src/randtobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(randtobin
 if (WIN32)
 	target_link_libraries(randtobin wingetopt)
 endif()
+
+install(TARGETS randtobin RUNTIME DESTINATION bin)

--- a/src/randtocsv/CMakeLists.txt
+++ b/src/randtocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(randtocsv
 if (WIN32)
 	target_link_libraries(randtocsv wingetopt)
 endif()
+
+install(TARGETS randtocsv RUNTIME DESTINATION bin)

--- a/src/returnperiodtobin/CMakeLists.txt
+++ b/src/returnperiodtobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(returnperiodtobin
 if (WIN32)
 	target_link_libraries(returnperiodtobin wingetopt)
 endif()
+
+install(TARGETS returnperiodtobin RUNTIME DESTINATION bin)

--- a/src/returnperiodtocsv/CMakeLists.txt
+++ b/src/returnperiodtocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(returnperiodtocsv
 if (WIN32)
 	target_link_libraries(returnperiodtocsv wingetopt)
 endif()
+
+install(TARGETS returnperiodtocsv RUNTIME DESTINATION bin)

--- a/src/summarycalc/CMakeLists.txt
+++ b/src/summarycalc/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(summarycalc
 if (WIN32)
 	target_link_libraries(summarycalc wingetopt)
 endif()
+
+install(TARGETS summarycalc RUNTIME DESTINATION bin)

--- a/src/summarycalctobin/CMakeLists.txt
+++ b/src/summarycalctobin/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(summarycalctobin
 if (WIN32)
 	target_link_libraries(summarycalctobin wingetopt)
 endif()
+
+install(TARGETS summarycalctobin RUNTIME DESTINATION bin)

--- a/src/summarycalctocsv/CMakeLists.txt
+++ b/src/summarycalctocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(summarycalctocsv
 if (WIN32)
 	target_link_libraries(summarycalctocsv wingetopt)
 endif()
+
+install(TARGETS summarycalctocsv RUNTIME DESTINATION bin)

--- a/src/summaryindex/CMakeLists.txt
+++ b/src/summaryindex/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(summaryindex
 if (WIN32)
 	target_link_libraries(summaryindex wingetopt)
 endif()
+
+install(TARGETS summaryindex RUNTIME DESTINATION bin)

--- a/src/validatedamagebin/CMakeLists.txt
+++ b/src/validatedamagebin/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(validatedamagebin)
+target_sources(validatedamagebin
+	PRIVATE
+		validatedamagebin.cpp main.cpp
+)
+
+if (WIN32)
+	target_link_libraries(validatedamagebin wingetopt)
+endif()
+
+install(TARGETS validatedamagebin RUNTIME DESTINATION bin)

--- a/src/validatefootprint/CMakeLists.txt
+++ b/src/validatefootprint/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(validatefootprint)
+target_sources(validatefootprint
+	PRIVATE
+		validatefootprint.cpp main.cpp
+)
+
+if (WIN32)
+	target_link_libraries(validatefootprint wingetopt)
+endif()
+
+install(TARGETS validatefootprint RUNTIME DESTINATION bin)

--- a/src/validateitems/CMakeLists.txt
+++ b/src/validateitems/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(validateitems
 if (WIN32)
 	target_link_libraries(validateitems wingetopt)
 endif()
+
+install(TARGETS validateitems RUNTIME DESTINATION bin)

--- a/src/validateoasisfiles/CMakeLists.txt
+++ b/src/validateoasisfiles/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(validateoasisfiles)
+target_sources(validateoasisfiles
+	PRIVATE
+		validateoasisfiles.cpp main.cpp
+)
+
+if (WIN32)
+	target_link_libraries(validateoasisfiles wingetopt)
+endif()
+
+install(TARGETS validateoasisfiles RUNTIME DESTINATION bin)

--- a/src/validatevulnerability/CMakeLists.txt
+++ b/src/validatevulnerability/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(validatevulnerability)
+target_sources(validatevulnerability
+	PRIVATE
+		validatevulnerability.cpp main.cpp
+)
+
+if (WIN32)
+	target_link_libraries(validatevulnerability wingetopt)
+endif()
+
+install(TARGETS validatevulnerability RUNTIME DESTINATION bin)

--- a/src/vulnerabilitytobin/CMakeLists.txt
+++ b/src/vulnerabilitytobin/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(vulnerabilitytobin
 if (WIN32)
 	target_link_libraries(vulnerabilitytobin wingetopt)
 endif()
+
+install(TARGETS vulnerabilitytobin RUNTIME DESTINATION bin)

--- a/src/vulnerabilitytocsv/CMakeLists.txt
+++ b/src/vulnerabilitytocsv/CMakeLists.txt
@@ -7,3 +7,5 @@ target_sources(vulnerabilitytocsv
 if (WIN32)
 	target_link_libraries(vulnerabilitytocsv wingetopt)
 endif()
+
+install(TARGETS vulnerabilitytocsv RUNTIME DESTINATION bin)


### PR DESCRIPTION
Updates to the CMake build files:
* Added all new executables
* Version is read from the `VERSION.in`
* Builds and tests can now run from an arbitrary directory (i.e. not required to build in-source).
* Added installation statements, so CMake can copy all ktools executables to a specified directory.