### PR TITLE
Add conditional call to correlated writer function for gul alloc rule 0

### DIFF
--- a/src/gulcalc/gulcalc.cpp
+++ b/src/gulcalc/gulcalc.cpp
@@ -1010,6 +1010,7 @@ void gulcalc::mode0()
 	if (itemWriter_)  itemWriter_(ibuf_, sizeof(unsigned char), itembufoffset_);
 	if (lossWriter_)  lossWriter_(ibuf_, sizeof(unsigned char), itembufoffset_);
 	if (coverageWriter_) coverageWriter_(cbuf_, sizeof(unsigned char), covbufoffset_);
+	if (correlatedWriter_) correlatedWriter_(corrbuf_, sizeof(unsigned char), correlatedbufoffset_);
 
 	delete[] rec;
 }


### PR DESCRIPTION
Call to `correlatedWriter_()` was absent in the `mode0()` method. This should have meant that only a header would have been written to the fully correlated GUL file. The fact that perfectly reasonable looking data found its way into the fully correlated GUL stream shows how dangerous buffers can be.