### PR TITLE
Change missing intensity bins error to warning in validatevulnerability for single peril models

### DIFF
--- a/src/validatevulnerability/validatevulnerability.cpp
+++ b/src/validatevulnerability/validatevulnerability.cpp
@@ -24,7 +24,8 @@ namespace validatevulnerability {
 
   inline bool ProbabilityError(Vulnerability v, float prob) {
 
-    fprintf(stderr, "Probabilities for vulnerability ID %d", v.vulnerability_id);
+    fprintf(stderr, "Error: Probabilities for vulnerability ID %d",
+	    v.vulnerability_id);
     fprintf(stderr, " and intensity bin ID %d", v.intensity_bin_id);
     fprintf(stderr, " do not sum to 1.\n");
     fprintf(stderr, "Probability = %f\n", prob);
@@ -82,7 +83,7 @@ namespace validatevulnerability {
       if(sscanf(line, "%d,%d,%d,%f", &q.vulnerability_id, &q.intensity_bin_id,
 		&q.damage_bin_id, &q.probability) != 4) {
 
-	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);
+	fprintf(stderr, "Error: Invalid data in line %d:\n%s\n", lineno, line);
 	dataValid = false;
 
       }
@@ -104,7 +105,8 @@ namespace validatevulnerability {
 	// Check vulnerability IDs listed in ascending order
 	if(q.vulnerability_id < p.vulnerability_id) {
 
-	  fprintf(stderr, "Vulnerability ID in lines %d and %d", lineno-1, lineno);
+	  fprintf(stderr, "Error: Vulnerability ID in lines %d and %d",
+		  lineno-1, lineno);
 	  fprintf(stderr, " not in ascending order:\n");
 	  fprintf(stderr, "%s\n%s\n", prevLine, line);
 
@@ -141,7 +143,7 @@ namespace validatevulnerability {
 	// Check intensity bin IDs are contiguous
 	if(p.intensity_bin_id != q.intensity_bin_id-1) {
 
-	  fprintf(stderr, "Non-contiguous intensity bin IDs");
+	  fprintf(stderr, "Error: Non-contiguous intensity bin IDs");
 	  fprintf(stderr, " in lines %d and %d\n", lineno-1, lineno);
 	  fprintf(stderr, "%s\n%s\n", prevLine, line);
 
@@ -167,7 +169,7 @@ namespace validatevulnerability {
 
       } else {
 
-	fprintf(stderr, "Duplicate damage bin for");
+	fprintf(stderr, "Error: Duplicate damage bin for");
 	fprintf(stderr, " vulnerability-intensity bin combination\n");
 	fprintf(stderr, "%s\n", line);
 	dataValid = false;
@@ -197,25 +199,31 @@ namespace validatevulnerability {
 		    	   maxIntensityBin);
 
     // Loop through vulnerability_id-maximum_intensity_bin_id map to ensure all
-    // intensity bins are present
+    // intensity bins are present. This is only a requirement for single peril
+    // models, so a warning should be issued rather than an error.
+    bool missingIntensityBins = false;
     for (std::map<int, int>::iterator it=vulID_to_maxIntensityBin.begin();
 	 it!=vulID_to_maxIntensityBin.end(); ++it) {
 
       if (maxIntensityBin > it->second) {
 
-	fprintf(stderr, "Vulnerability ID %d: ", it->first);
+	if (missingIntensityBins == false) {
+	  fprintf(stderr, "Warning: All intensity bins must be present for "
+			  "each vulnerability ID in single peril models:\n");
+	  missingIntensityBins = true;
+	}
+
+	fprintf(stderr, "Warning: Vulnerability ID %d: ", it->first);
 	fprintf(stderr, "%d out of %d intensity bins present\n", it->second,
 		maxIntensityBin);
-
-	dataValid = false;
 
       }
 
     }
 
-    if(dataValid == true) {
+    if (dataValid == true) {
 
-      fprintf(stderr, "All checks pass.\n");
+      fprintf(stderr, "All checks pass.  Please take note of any warnings.\n");
       fprintf(stderr, "Maximum value of damage_bin_index = %d\n", maxDamageBin);
 
     } else {


### PR DESCRIPTION
Validation requiring all intensity bins to be present now issues a warning rather than an error:

```
Warning: All intensity bins must be present for each vulnerability ID in single peril models:
Warning: Vulnerability ID 1: 29 out of 58 intensity bins present
Warning: Vulnerability ID 2: 29 out of 58 intensity bins present
Warning: Vulnerability ID 3: 29 out of 58 intensity bins present
Warning: Vulnerability ID 4: 29 out of 58 intensity bins present
Warning: Vulnerability ID 5: 29 out of 58 intensity bins present
Warning: Vulnerability ID 6: 29 out of 58 intensity bins present
All checks pass.  Please take note of any warnings.
Maximum value of damage_bin_index = 12
```