### PR TITLE
Add new gulcalc alloc rule where total peril loss = maximum subperil loss

### DIFF
--- a/src/gulcalc/doit.cpp
+++ b/src/gulcalc/doit.cpp
@@ -174,6 +174,10 @@ void doit(const gulcalcopts &opt)
 	if (opt.itemLevelOutput == true) {
 		if (opt.allocRule == 0 || opt.allocRule == 1) lossWriter = itemWriter;   // If alloc rule has been specified
 		else if (opt.mode == 0) itmWriter = itemWriter;
+		else {
+			fprintf(stderr, "FATAL: gulcalc: Invalid combination of alloc rule %d and mode %d\n", opt.allocRule, opt.mode);
+			exit(-1);
+		}
 	}
 	if (opt.coverageLevelOutput == true) covWriter = coverageWriter;
     	if(opt.correlatedLevelOutput == true) corrWriter = correlatedWriter;

--- a/src/gulcalc/doit.cpp
+++ b/src/gulcalc/doit.cpp
@@ -172,7 +172,7 @@ void doit(const gulcalcopts &opt)
 	covout = opt.covout;
 	corrout = opt.corrout;
 	if (opt.itemLevelOutput == true) {
-		if (opt.allocRule == 0 || opt.allocRule == 1) lossWriter = itemWriter;   // If alloc rule has been specified
+		if (opt.allocRule == 0 || opt.allocRule == 1 || opt.allocRule == 2) lossWriter = itemWriter;   // If alloc rule has been specified
 		else if (opt.mode == 0) itmWriter = itemWriter;
 		else {
 			fprintf(stderr, "FATAL: gulcalc: Invalid combination of alloc rule %d and mode %d\n", opt.allocRule, opt.mode);

--- a/src/gulcalc/gulcalc.h
+++ b/src/gulcalc/gulcalc.h
@@ -148,6 +148,7 @@ private:
 	void fillgulitemloss(const int item_id, const OASIS_FLOAT tiv, const int event_id, const int bin_index, const OASIS_FLOAT rval, const probrec &p, const int sample_id, std::vector<std::vector<gulItemIDLoss>> &gilv);
 	void writemode0output(const item_map_rec &er, const OASIS_FLOAT tiv, const int event_id, const int bin_index, const OASIS_FLOAT rval, const probrec &p, const int sample_id, const bool correlated);
 	void writemode1output(const int event_id, const OASIS_FLOAT tiv, std::vector<std::vector<gulItemIDLoss>> &gilv, const bool correlated);
+	void setmaxloss(std::vector<std::vector<gulItemIDLoss>> &gilv);
 	void(*itemWriter_)(const void *ibuf, int size, int count);
 	void(*coverageWriter_)(const void *ibuf, int size, int count);
     void (*lossWriter_)(const void *ibuf, int size, int count);	// loss stream writer
@@ -164,6 +165,7 @@ private:
 	int itembufoffset_ = 0;
 	int correlatedbufoffset_ = 0;
 	int covbufoffset_ = 0;
+	int alloc_rule_;
 	double loss_threshold_;
 	rd_option rndopt_;
 	bool debug_;
@@ -214,6 +216,7 @@ public:
 		cbuf_ = new unsigned char[bufsize + sizeof(gulitemSampleslevel)]; // make the allocation bigger by 1 record to avoid overrunning
 		//TODO: when using double precision, these buffers above are overflowing,
 		//the hack fix is to replace sizeof(gulitemSampleslevel) with 2*sizeof(gulitemSampleslevel)
+		alloc_rule_ = opt.allocRule;
 		loss_threshold_ = opt.loss_threshold;
 		rndopt_ = opt.rndopt;				
 		debug_ = opt.debug;

--- a/src/gulcalc/main.cpp
+++ b/src/gulcalc/main.cpp
@@ -102,7 +102,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'a':
 			gopt.allocRule = atoi(optarg);
-			gopt.mode = gopt.allocRule;   // set mode to alloc rule
+			// Set mode according to alloc rule
+			if (gopt.allocRule > 0) gopt.mode = 1;
+			else gopt.mode = 0;   // alloc rule = 0 loss stream is equivalent to deprecated item stream
 			break;
 		case 'b':
 			gopt.benchmark = true;


### PR DESCRIPTION
New alloc rule assigned number 2. This can be changed if desired. Please supply argument `-a2` to try it out.