### PR TITLE
Fix gulcalc performance issues

### DIFF
--- a/src/gulcalc/gulcalc.cpp
+++ b/src/gulcalc/gulcalc.cpp
@@ -689,7 +689,7 @@ void gulcalc::output_mean_mode1(const OASIS_FLOAT tiv, prob_mean *pp,
 		auto pos = bin_map_.find(*pp);
 		if (pos == bin_map_.end()) {
 			bin_map_[*pp] = bin_map_.size();
-			bin_lookup_[bin_map_[*pp]] = *pp;
+			bin_lookup_.push_back(*pp);
 		}
 		bin_ids.push_back(bin_map_[*pp]);
 

--- a/src/gulcalc/gulcalc.cpp
+++ b/src/gulcalc/gulcalc.cpp
@@ -689,6 +689,7 @@ void gulcalc::output_mean_mode1(const OASIS_FLOAT tiv, prob_mean *pp,
 		auto pos = bin_map_.find(*pp);
 		if (pos == bin_map_.end()) {
 			bin_map_[*pp] = bin_map_.size();
+			bin_lookup_[bin_map_[*pp]] = *pp;
 		}
 		bin_ids.push_back(bin_map_[*pp]);
 
@@ -773,19 +774,6 @@ void gulcalc::processrec_mode1(char* rec, int recsize) {
 
 			iter++;
 
-		}
-
-	}
-
-	// Should be able to reuse damage bin map in most cases so only remake
-	// inverted lookup map if additional bins encountered
-	if (bin_map_.size() > bin_lookup_.size()) {
-
-		bin_lookup_.clear();
-		auto iter = bin_map_.begin();
-		while (iter != bin_map_.end()) {
-			bin_lookup_[iter->second] = iter->first;
-			iter++;
 		}
 
 	}

--- a/src/gulcalc/gulcalc.h
+++ b/src/gulcalc/gulcalc.h
@@ -138,7 +138,7 @@ private:
 	std::vector<std::vector<std::vector<gulItemIDLoss>>> fullCorr_;
 	std::vector<std::vector<processrecData>> mode1_stats_;
 	std::map<prob_mean, int> bin_map_;
-	std::map<int, prob_mean> bin_lookup_;
+	std::vector<prob_mean> bin_lookup_;
 	std::vector<int> mode1UsedCoverageIDs_;
 	void covoutputgul(gulcoverageSampleslevel &gc);
 	void outputcoveragedata(int event_id);


### PR DESCRIPTION
Remove the unnecessary rewriting of `bin_lookup_` and change its type from `map<int, prob_mean>` to `vector<prob_mean>`. This results in a significant improvement in performance of `gulcalc` when alloc rules 1 or 2 are used. @johcarter's  performance test (in `ktest` repo under `periltest2/perftest`) now yields the following:

```
$ bash runtests_tmp.sh 
Alloc rule 0

real	0m1.028s
user	0m0.015s
sys	0m0.012s
Alloc rule 1

real	0m1.733s
user	0m0.712s
sys	0m0.020s
Alloc rule 2

real	0m1.695s
user	0m0.663s
sys	0m0.032s
```