### PR TITLE
Remove records where interpolated return period loss runs out of bounds in leccalc

### DIFF
--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -577,8 +577,6 @@ void aggreports::wheatsheafwithweighting(int handle, const std::map<outkey2, OAS
 		size_t nextreturnperiodindex = 0;
 		OASIS_FLOAT last_computed_rp = 0;
 		OASIS_FLOAT last_computed_loss = 0;
-		int i = 1;
-		OASIS_FLOAT t = (OASIS_FLOAT)totalperiods_;
 		OASIS_FLOAT max_retperiod = 0;
 		bool largest_loss = false;
 		for (auto lp : lpv) {
@@ -596,7 +594,6 @@ void aggreports::wheatsheafwithweighting(int handle, const std::map<outkey2, OAS
 				else {
 					fprintf(fout_[handle], "%d,%d,%f,%f\n", s.first.summary_id, s.first.sidx, retperiod, lp.value);
 				}
-				i++;
 			}
 		}
 		if (useReturnPeriodFile_) {

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -211,6 +211,8 @@ inline void aggreports::writefulluncertainty(const int handle, const int type,
 		size_t nextreturnperiodindex = 0;
 		OASIS_FLOAT last_computed_rp = 0;
 		OASIS_FLOAT last_computed_loss = 0;
+		OASIS_FLOAT max_retperiod = 0;
+		bool largest_loss = false;
 		for (auto lp : lpv) {
 			if (type == 1) {
 				cummulative_weighting += (lp.period_weighting * samplesize_);
@@ -220,8 +222,12 @@ inline void aggreports::writefulluncertainty(const int handle, const int type,
 
 			if (lp.period_weighting) {
 				OASIS_FLOAT retperiod = 1 / cummulative_weighting;
+				if (!largest_loss) {
+					max_retperiod = retperiod;
+					largest_loss = true;
+				}
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, s.first, type);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, s.first, type, max_retperiod);
 				}
 				else {
 					fprintf(fout_[handle], "%d,%d,%f,%f\n", s.first, type, retperiod, lp.value);
@@ -259,6 +265,8 @@ void aggreports::fulluncertainty(int handle,const std::map<outkey2, OASIS_FLOAT>
 		fprintf(fout_[handle], "\n");
 	}
 
+	OASIS_FLOAT max_retperiod = (OASIS_FLOAT)totalperiods_;
+
 	for (auto s : items) {
 		lossvec &lpv = s.second;
 		std::sort(lpv.rbegin(), lpv.rend());
@@ -270,7 +278,7 @@ void aggreports::fulluncertainty(int handle,const std::map<outkey2, OASIS_FLOAT>
 		for (auto lp : lpv) {
 			OASIS_FLOAT retperiod = t / i;
 			if (useReturnPeriodFile_) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first, 1);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first, 1, max_retperiod);
 			}else{
 				fprintf(fout_[handle],"%d,1,%f,%f", s.first, retperiod, lp);
 				if (ensembletosidx_.size() > 0) fprintf(fout_[handle], ",0");
@@ -279,9 +287,9 @@ void aggreports::fulluncertainty(int handle,const std::map<outkey2, OASIS_FLOAT>
 			i++;
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 1);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 1, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 1);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 1, max_retperiod);
 			}
 		}
 
@@ -302,10 +310,11 @@ void aggreports::fulluncertainty(int handle,const std::map<outkey2, OASIS_FLOAT>
 		int i = 1;
 		OASIS_FLOAT t = (OASIS_FLOAT)totalperiods_;
 		if (samplesize_) t *= samplesize_;
+		max_retperiod = t;
 		for (auto lp : lpv) {
 			OASIS_FLOAT retperiod = t / i;
 			if (useReturnPeriodFile_) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first, 2);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first, 2, max_retperiod);
 			}
 			else {
 				fprintf(fout_[handle], "%d,2,%f,%f", s.first, retperiod, lp);
@@ -315,9 +324,9 @@ void aggreports::fulluncertainty(int handle,const std::map<outkey2, OASIS_FLOAT>
 			i++;
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2, max_retperiod);
 			}
 		}
 
@@ -341,19 +350,20 @@ void aggreports::fulluncertainty(int handle,const std::map<outkey2, OASIS_FLOAT>
 				int i = 1;
 				OASIS_FLOAT t = (OASIS_FLOAT)totalperiods_;
 				if (ensemble.second.size() > 0) t *= ensemble.second.size();
+				max_retperiod = t;
 				for (auto lp : lpv) {
 					OASIS_FLOAT retperiod = t / i;
 					if (useReturnPeriodFile_) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first, 2, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first, 2, max_retperiod, ensemble.first);
 					} else {
 						fprintf(fout_[handle], "%d,2,%f,%f,%d\n", s.first, retperiod, lp, ensemble.first);
 					}
 					i++;
 				}
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2, ensemble.first);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2, max_retperiod, ensemble.first);
 					while (nextreturnperiodindex < returnperiods_.size()) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first, 2, max_retperiod, ensemble.first);
 					}
 				}
 
@@ -407,15 +417,27 @@ OASIS_FLOAT aggreports::getloss(OASIS_FLOAT next_return_period, OASIS_FLOAT last
 	return -1;		// we should NOT get HERE hence the -1 !!!
 }
 
-void aggreports::doreturnperiodout(int handle, size_t &nextreturnperiod_index, OASIS_FLOAT &last_return_period, OASIS_FLOAT &last_loss,
-			OASIS_FLOAT current_return_period, OASIS_FLOAT current_loss, int summary_id, int type, int ensemble_id)
+void aggreports::doreturnperiodout(int handle, size_t &nextreturnperiod_index,
+				   OASIS_FLOAT &last_return_period,
+				   OASIS_FLOAT &last_loss,
+				   OASIS_FLOAT current_return_period,
+				   OASIS_FLOAT current_loss, int summary_id,
+				   int type, OASIS_FLOAT max_retperiod,
+				   int ensemble_id)
 {
 	if (nextreturnperiod_index >= returnperiods_.size()) {
 		return;
 	}
 	OASIS_FLOAT nextreturnperiod_value = returnperiods_[nextreturnperiod_index];
 	while (current_return_period <= nextreturnperiod_value) {
-		OASIS_FLOAT loss = getloss(nextreturnperiod_value, last_return_period, last_loss, current_return_period, current_loss);
+		// Interpolated return period loss should not exceed that for
+		// maximum return period
+		OASIS_FLOAT loss;
+		if (max_retperiod < nextreturnperiod_value) {
+			loss = getloss(max_retperiod, last_return_period, last_loss, current_return_period, current_loss);
+		} else {
+			loss = getloss(nextreturnperiod_value, last_return_period, last_loss, current_return_period, current_loss);
+		}
 		if(type) {
 			fprintf(fout_[handle],"%d,%d,%f,%f", summary_id, type, (OASIS_FLOAT)nextreturnperiod_value, loss);
 			if (ensembletosidx_.size() > 0) fprintf(fout_[handle], ",%d", ensemble_id);
@@ -457,6 +479,8 @@ void aggreports::wheatsheaf(int handle, const std::map<outkey2, OASIS_FLOAT> &ou
 		fprintf(fout_[handle], "\n");
 	}
 
+	OASIS_FLOAT max_retperiod = (OASIS_FLOAT)totalperiods_;
+
 	for (auto s : items) {
 		if (s.first.sidx == -1) continue;		// skip -1 from wheatsheaf output
 		lossvec &lpv = s.second;
@@ -470,7 +494,7 @@ void aggreports::wheatsheaf(int handle, const std::map<outkey2, OASIS_FLOAT> &ou
 			OASIS_FLOAT retperiod = t / i;
 			if (useReturnPeriodFile_) {
 				if (nextreturnperiodindex == returnperiods_.size()) break;
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first.summary_id, s.first.sidx);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first.summary_id, s.first.sidx, max_retperiod);
 			}else {
 				fprintf(fout_[handle],"%d,%d,%f,%f", s.first.summary_id, s.first.sidx, t / i, lp);
 				if (ensembletosidx_.size() > 0) fprintf(fout_[handle], ",0");
@@ -479,9 +503,9 @@ void aggreports::wheatsheaf(int handle, const std::map<outkey2, OASIS_FLOAT> &ou
 			i++;
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, max_retperiod);
 			}
 		}
 
@@ -503,16 +527,16 @@ void aggreports::wheatsheaf(int handle, const std::map<outkey2, OASIS_FLOAT> &ou
 					OASIS_FLOAT retperiod = t / i;
 					if (useReturnPeriodFile_) {
 						if (nextreturnperiodindex == returnperiods_.size()) break;
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first.summary_id, s.first.sidx, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first.summary_id, s.first.sidx, max_retperiod, ensemble.first);
 					}else {
 						fprintf(fout_[handle],"%d,%d,%f,%f,%d\n", s.first.summary_id, s.first.sidx, t / i, lp, ensemble.first);
 					}
 					i++;
 				}
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, ensemble.first);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, max_retperiod, ensemble.first);
 					while (nextreturnperiodindex < returnperiods_.size()) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, max_retperiod, ensemble.first);
 					}
 				}
 
@@ -555,13 +579,19 @@ void aggreports::wheatsheafwithweighting(int handle, const std::map<outkey2, OAS
 		OASIS_FLOAT last_computed_loss = 0;
 		int i = 1;
 		OASIS_FLOAT t = (OASIS_FLOAT)totalperiods_;
+		OASIS_FLOAT max_retperiod = 0;
+		bool largest_loss = false;
 		for (auto lp : lpv) {
 			cummulative_weighting += (OASIS_FLOAT)lp.period_weighting * samplesize_;
 			if (lp.period_weighting) {
 				OASIS_FLOAT retperiod = 1 / cummulative_weighting;
+				if (!largest_loss) {
+					max_retperiod = retperiod;
+					largest_loss = true;
+				}
 				if (useReturnPeriodFile_) {
 					if (nextreturnperiodindex == returnperiods_.size()) break;
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, s.first.summary_id, s.first.sidx);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, s.first.summary_id, s.first.sidx, max_retperiod);
 				}
 				else {
 					fprintf(fout_[handle], "%d,%d,%f,%f\n", s.first.summary_id, s.first.sidx, retperiod, lp.value);
@@ -570,9 +600,9 @@ void aggreports::wheatsheafwithweighting(int handle, const std::map<outkey2, OAS
 			}
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, s.first.sidx, max_retperiod);
 			}
 		}
 
@@ -635,6 +665,8 @@ void aggreports::wheatSheafMeanwithweighting(int samplesize, int handle, const s
 		lossvec2 &lpv = s.second;
 		std::sort(lpv.rbegin(), lpv.rend());
 		OASIS_FLOAT cummulative_weighting = 0;
+		OASIS_FLOAT max_retperiod = 0;
+		bool largest_loss = false;
 		if (s.first.sidx != -1) {
 			for (auto lp : lpv) {
 				lossval &l = mean_map[s.first.summary_id][lp.period_no-1];
@@ -648,8 +680,12 @@ void aggreports::wheatSheafMeanwithweighting(int samplesize, int handle, const s
 				cummulative_weighting += (OASIS_FLOAT)(lp.period_weighting * samplesize_);
 				if (lp.period_weighting) {
 					OASIS_FLOAT retperiod = 1 / cummulative_weighting;
+					if (!largest_loss) {
+						max_retperiod = retperiod;
+						largest_loss = true;
+					}
 					if (useReturnPeriodFile_) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, s.first.summary_id, 1);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, s.first.summary_id, 1, max_retperiod);
 					}
 					else {
 						fprintf(fout_[handle], "%d,1,%f,%f\n", s.first.summary_id, retperiod, lp.value);
@@ -658,9 +694,9 @@ void aggreports::wheatSheafMeanwithweighting(int samplesize, int handle, const s
 
 			}
 			if (useReturnPeriodFile_) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, 1);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, 1, max_retperiod);
 				while (nextreturnperiodindex < returnperiods_.size()) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, 1);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, 1, max_retperiod);
 				}
 			}
 		}
@@ -682,13 +718,19 @@ void aggreports::wheatSheafMeanwithweighting(int samplesize, int handle, const s
 		OASIS_FLOAT last_computed_loss = 0;
 		int i = 1;
 		OASIS_FLOAT cummulative_weighting = 0;
+		OASIS_FLOAT max_retperiod = 0;
+		bool largest_loss = false;
 		for (auto lp : lpv) {
 			cummulative_weighting += (OASIS_FLOAT)(lp.period_weighting * samplesize_);
 			if (lp.period_weighting) {
 				OASIS_FLOAT retperiod = 1 / cummulative_weighting;
+				if (!largest_loss) {
+					max_retperiod = retperiod;
+					largest_loss = true;
+				}
 				if (useReturnPeriodFile_) {
 					OASIS_FLOAT loss = lp.value / samplesize;
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, loss, m.first, 2);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, loss, m.first, 2, max_retperiod);
 				}
 				else {
 					fprintf(fout_[handle], "%d,2,%f,%f\n", m.first, retperiod, lp.value / samplesize);
@@ -698,9 +740,9 @@ void aggreports::wheatSheafMeanwithweighting(int samplesize, int handle, const s
 			if (i > maxindex) break;
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, max_retperiod);
 			}
 		}
 	}
@@ -731,6 +773,9 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 		if (ensembletosidx_.size() > 0) fprintf(fout_[handle], ",ensemble_id");
 		fprintf(fout_[handle], "\n");
 	}
+
+	OASIS_FLOAT max_retperiod = (OASIS_FLOAT)totalperiods_;
+
 	for (auto s : items) {
 		size_t nextreturnperiodindex = 0;
 		OASIS_FLOAT last_computed_rp = 0;
@@ -750,7 +795,7 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 			for (auto lp : lpv) {
 				OASIS_FLOAT retperiod = t / i;
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first.summary_id,1);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, s.first.summary_id, 1, max_retperiod);
 				}else {
 					fprintf(fout_[handle],"%d,1,%f,%f\n", s.first.summary_id, retperiod, lp);
 				}
@@ -758,9 +803,9 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 				i++;
 			}
 			if (useReturnPeriodFile_) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id,1);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, 1, max_retperiod);
 				while (nextreturnperiodindex < returnperiods_.size()) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id,1);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, s.first.summary_id, 1, max_retperiod);
 				}
 			}
 		}
@@ -786,7 +831,7 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 			OASIS_FLOAT retperiod = t / i;
 			if (useReturnPeriodFile_) {
 				OASIS_FLOAT loss = lp / samplesize;
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, loss, m.first,2);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, loss, m.first, 2, max_retperiod);
 			}else {
 				fprintf(fout_[handle],"%d,2,%f,%f\n", m.first, retperiod, lp / samplesize);
 			}
@@ -794,9 +839,9 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 			if (i > maxindex) break;
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, max_retperiod);
 			}
 		}
 	}
@@ -848,7 +893,7 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 					OASIS_FLOAT retperiod = t / i;
 					if (useReturnPeriodFile_) {
 						OASIS_FLOAT loss = lp / ensemble.second.size();
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, loss, m.first,2, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, loss, m.first,2, max_retperiod, ensemble.first);
 					} else {
 						fprintf(fout_[handle],"%d,2,%f,%f,%d\n", m.first, retperiod, lp / ensemble.second.size(), ensemble.first);
 					}
@@ -856,9 +901,9 @@ void aggreports::wheatSheafMean(int samplesize, int handle, const std::map<outke
 					if (i > maxindex) break;
 				}
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, ensemble.first);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, max_retperiod, ensemble.first);
 					while (nextreturnperiodindex < returnperiods_.size()) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, 2, max_retperiod, ensemble.first);
 					}
 				}
 			}
@@ -906,12 +951,18 @@ inline void aggreports::writeSampleMean(const int handle, const int type,
 		OASIS_FLOAT last_computed_rp = 0;
 		OASIS_FLOAT last_computed_loss = 0;
 		OASIS_FLOAT cummulative_weighting = 0;
+		OASIS_FLOAT max_retperiod = 0;
+		bool largest_loss = false;
 		for (auto lp : lpv) {
 			cummulative_weighting += (OASIS_FLOAT) (lp.period_weighting * samplesize_);
 			if (lp.period_weighting) {
 				OASIS_FLOAT retperiod = 1 / cummulative_weighting;
+				if (!largest_loss) {
+					max_retperiod = retperiod;
+					largest_loss = true;
+				}
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, m.first, type);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp.value, m.first, type, max_retperiod);
 				}
 				else {
 					fprintf(fout_[handle], "%d,%d,%f,%f\n", m.first, type, retperiod, lp.value);
@@ -919,9 +970,9 @@ inline void aggreports::writeSampleMean(const int handle, const int type,
 			}
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, type);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, type, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, type);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first, type, max_retperiod);
 			}
 		}
 	}
@@ -1001,6 +1052,8 @@ void aggreports::sampleMean(int samplesize, int handle, const std::map<outkey2, 
 		mean_map[st].push_back(s.second);
 	}
 
+	OASIS_FLOAT max_retperiod = (OASIS_FLOAT)totalperiods_;
+
 	for (auto m : mean_map) {
 		std::vector<OASIS_FLOAT> &lpv = m.second;
 		std::sort(lpv.rbegin(), lpv.rend());
@@ -1012,7 +1065,7 @@ void aggreports::sampleMean(int samplesize, int handle, const std::map<outkey2, 
 		for (auto lp : lpv) {
 			OASIS_FLOAT retperiod = t / i;
 			if (useReturnPeriodFile_) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, m.first.summary_id, m.first.type);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, m.first.summary_id, m.first.type, max_retperiod);
 			}else {
 				fprintf(fout_[handle],"%d,%d,%f,%f", m.first.summary_id, m.first.type, retperiod, lp);
 				if (ensembletosidx_.size() > 0) fprintf(fout_[handle], ",0");
@@ -1021,9 +1074,9 @@ void aggreports::sampleMean(int samplesize, int handle, const std::map<outkey2, 
 			i++;
 		}
 		if (useReturnPeriodFile_) {
-			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type);
+			doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type, max_retperiod);
 			while (nextreturnperiodindex < returnperiods_.size()) {
-				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type);
+				doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type, max_retperiod);
 			}
 		}
 	}
@@ -1063,16 +1116,16 @@ void aggreports::sampleMean(int samplesize, int handle, const std::map<outkey2, 
 				for (auto lp : lpv) {
 					OASIS_FLOAT retperiod = t / i;
 					if (useReturnPeriodFile_) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, m.first.summary_id, m.first.type, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, retperiod, lp, m.first.summary_id, m.first.type, max_retperiod, ensemble.first);
 					} else {
 						fprintf(fout_[handle],"%d,%d,%f,%f,%d\n", m.first.summary_id, m.first.type, retperiod, lp, ensemble.first);
 					}
 					i++;
 				}
 				if (useReturnPeriodFile_) {
-					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type, ensemble.first);
+					doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type, max_retperiod, ensemble.first);
 					while (nextreturnperiodindex < returnperiods_.size()) {
-						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type, ensemble.first);
+						doreturnperiodout(handle, nextreturnperiodindex, last_computed_rp, last_computed_loss, 0, 0, m.first.summary_id, m.first.type, max_retperiod, ensemble.first);
 					}
 				}
 			}

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -434,7 +434,13 @@ void aggreports::doreturnperiodout(int handle, size_t &nextreturnperiod_index,
 		// maximum return period
 		OASIS_FLOAT loss;
 		if (max_retperiod < nextreturnperiod_value) {
-			loss = getloss(max_retperiod, last_return_period, last_loss, current_return_period, current_loss);
+			nextreturnperiod_index++;
+			if (nextreturnperiod_index < returnperiods_.size()) {
+				nextreturnperiod_value = (OASIS_FLOAT)returnperiods_[nextreturnperiod_index];
+			} else {
+				break;
+			}
+			continue;
 		} else {
 			loss = getloss(nextreturnperiod_value, last_return_period, last_loss, current_return_period, current_loss);
 		}

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -70,8 +70,13 @@ private:
 	void loadreturnperiods();
 	OASIS_FLOAT getloss(OASIS_FLOAT nextreturnperiod, OASIS_FLOAT last_return_period, OASIS_FLOAT last_loss, 
 		OASIS_FLOAT current_return_period, OASIS_FLOAT current_loss) const;
-	void doreturnperiodout(int handle, size_t &nextreturnperiod_index, OASIS_FLOAT &last_return_period, OASIS_FLOAT &last_loss,
-		OASIS_FLOAT current_return_period, OASIS_FLOAT current_loss, int summary_id, int type, int ensemble_id=0);
+	void doreturnperiodout(int handle, size_t &nextreturnperiod_index,
+			       OASIS_FLOAT &last_return_period,
+			       OASIS_FLOAT &last_loss,
+			       OASIS_FLOAT current_return_period,
+			       OASIS_FLOAT current_loss, int summary_id,
+			       int type, OASIS_FLOAT max_retperiod,
+			       int ensemble_id=0);
 public:
 	void loadperiodtoweigthing();
 	void loadensemblemapping();


### PR DESCRIPTION
Losses for Interpolated return periods that exceed largest return period are capped at the loss from the largest return period. For example, if the largest return period is 1000, the following:

```
summary_id,type,return_period,loss
1,1,5000.000000,7945315.000000
1,1,1000.000000,1589063.000000
1,1,500.000000,1082886.000000
```

Turns into:

```
summary_id,type,return_period,loss
1,1,5000.000000,1589063.000000
1,1,1000.000000,1589063.000000
1,1,500.000000,1082886.000000
```