### PR TITLE
Add stream type to gultobin

### DIFF
--- a/docs/md/StreamConversionComponents.md
+++ b/docs/md/StreamConversionComponents.md
@@ -201,6 +201,7 @@ A component which converts gulcalc data in csv format into gulcalc binary item s
 
 ##### Parameters
 -S, the number of samples must be provided.  This can be equal to or greater than maximum sample index value that appears in the csv data.
+-t, the stream type of either 1 for the deprecated item stream or 2 for the loss stream. This is an optional parameter with default value 2.
 
 ##### Usage
 ```
@@ -212,6 +213,8 @@ $ gultobin [parameters] < [input].csv > [output].bin
 ```
 $ gultobin -S100 < gulcalci.csv | fmcalc > fmcalc.bin
 $ gultobin -S100 < gulcalci.csv > gulcalci.bin
+$ gultobin -S100 -t1 < gulcalci.csv > gulcalci.bin
+$ gultobin -S100 -t2 < gulcalci.csv > gulcalci.bin
 ```
 
 ##### Standard output stream
@@ -219,6 +222,7 @@ $ gultobin -S100 < gulcalci.csv > gulcalci.bin
 | Byte 1 | Bytes 2-4 |  Description             |
 |:-------|-----------|:-------------------------|
 |    1   |     1     |  gulcalc item            |
+|    2   |     1     |  gulcalc loss            |
 
 [Return to top](#streamconversioncomponents)
 

--- a/src/gultobin/gultobin.cpp
+++ b/src/gultobin/gultobin.cpp
@@ -48,7 +48,7 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #endif
 
 namespace gultobin {
-	void doit(int maxsampleindex)
+	void doit(int maxsampleindex, int streamType)
 	{
 
 		gulitemSampleslevel q;
@@ -56,7 +56,12 @@ namespace gultobin {
 		int lineno = 0;
 		fgets(line, sizeof(line), stdin);
 		lineno++;
-		int gulstream_type = gulstream_id | 1;
+		int gulstream_type;
+		if (streamType == 1) {
+			gulstream_type = gulstream_id | 1;
+		} else {
+			gulstream_type = loss_stream_id | 1;
+		}
 		fwrite(&gulstream_type, sizeof(int), 1, stdout);
 		fwrite(&maxsampleindex, sizeof(int), 1, stdout);
 		gulSampleslevelHeader gh;

--- a/src/gultobin/main.cpp
+++ b/src/gultobin/main.cpp
@@ -55,7 +55,7 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 
 char* progname;
 namespace gultobin {
-	void doit(int maxsampleindex);
+	void doit(int maxsampleindex, int streamType);
 }
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
@@ -70,6 +70,7 @@ void help()
 {
 	fprintf(stderr,
 		"-S maximum sample index\n"
+		"-t stream type (default 2 = loss stream)\n"
 		"-h help\n"
 		"-v version\n");
 }
@@ -79,10 +80,14 @@ int main(int argc, char* argv[])
 
 	int opt;
 	int maxsampleindex = -1;
-	while ((opt = getopt(argc, argv, "vhS:")) != -1) {
+	int streamType = 2;
+	while ((opt = getopt(argc, argv, "vhS:t:")) != -1) {
 		switch (opt) {
 		case 'S':
 			maxsampleindex = atoi(optarg);
+			break;
+		case 't':
+			streamType = atoi(optarg);
 			break;
 		case 'v':
 			fprintf(stderr, "%s : version: %s\n", argv[0], VERSION);
@@ -112,7 +117,11 @@ int main(int argc, char* argv[])
 			fprintf(stderr, "FATAL: Sample size not supplied - please use -S parameter followed by the sample size\n");
 			exit(EXIT_FAILURE);
 		}
-		gultobin::doit(maxsampleindex);
+		if (streamType != 1 && streamType != 2) {
+			fprintf(stderr, "FATAL: Unknown stream type %d - please use 1 for item stream or 2 for loss stream\n", streamType);
+			exit(EXIT_FAILURE);
+		}
+		gultobin::doit(maxsampleindex, streamType);
 
 		return EXIT_SUCCESS;
 	}catch (std::bad_alloc&) {


### PR DESCRIPTION
As requested, the stream type can now be specified with the `-t` flag. The default stream type is that for the loss stream:

```
$ gultobin -S10 < guls.csv | hexdump | head -1
0000000 0001 0200 000a 0000 03b2 0000 0001 0000
$ gultobin -S10 -t1 < guls.csv | hexdump | head -1
0000000 0001 0100 000a 0000 03b2 0000 0001 0000
$ gultobin -S10 -t2 < guls.csv | hexdump | head -1
0000000 0001 0200 000a 0000 03b2 0000 0001 0000
```

@johcarter I have updated the md documentation. Please feel free to change it and update the pdf and html files before we merge into `develop`.