### PR TITLE
Implement step policies from loss stream in fmcalc

### DIFF
--- a/src/fmcalc/fmcalc.cpp
+++ b/src/fmcalc/fmcalc.cpp
@@ -803,8 +803,9 @@ void fmcalc::dofm(int event_id, const std::vector<int> &items, std::vector<vecto
 				int vid = aggid_to_vectorlookup[agg_id - 1];
 				agg_vec[vec_idx].agg_id = avx[1][vid].agg_id;
 				agg_vec[vec_idx].item_idx = &avx[1][vid].item_idx;
-				if (isGULStreamType_ == true)	agg_vec[vec_idx].accumulated_tiv = item_to_tiv_[avx[1][vid].item_idx[0]+1];
-				else agg_vec[vec_idx].accumulated_tiv = 0;
+				if (isGULStreamType_ == true || stepped_ == true) {
+					agg_vec[vec_idx].accumulated_tiv = item_to_tiv_[avx[1][vid].item_idx[0]+1];
+				} else agg_vec[vec_idx].accumulated_tiv = 0;
 				agg_vec[vec_idx].policytc_id = avx[1][vid].policytc_id;
 			}
 

--- a/src/fmcalc/fmcalcdoit.cpp
+++ b/src/fmcalc/fmcalcdoit.cpp
@@ -31,7 +31,7 @@ void fmcalc::doit()
 		isGULStreamType_ = false;
 		stream_type = streamno_mask & fmstream_type;
 	}
-	if (isGULStreamType_ == true) init_itemtotiv();
+	if (isGULStreamType_ == true || stepped_ == true) init_itemtotiv();
 	if (stream_type != 1) {
 		fprintf(stderr, "%s: Unsupported gul stream type %d\n", __func__, stream_type);
 		exit(-1);


### PR DESCRIPTION
Step policies require the TIVs to be read from `coverages.bin`. Prior to this PR, this has only been done for the deprecated item stream. This is now done for the loss stream too.