### PR TITLE
Improve performance of getmodel

### DIFF
--- a/src/getmodel/getmodel.h
+++ b/src/getmodel/getmodel.h
@@ -90,7 +90,7 @@ private:
 		AREAPERIL_INT &areaperil_id,
         std::map<AREAPERIL_INT, std::set<int> > &vulnerabilities_by_area_peril,
         std::map<int, std::vector<OASIS_FLOAT> > &vulnerabilities,
-        std::vector<OASIS_FLOAT> intensity) const;
+	std::map<int, OASIS_FLOAT> intensity) const;
 
 	void  doResultsNoIntensityUncertainty(
 		int &event_id,


### PR DESCRIPTION
`std::vector` of intensity bin probabilities replaced with `std::map`. This effectively removes intensity bins with zero probability from being looped over when there is uncertainty in the footprint file, saving some execution time.