### PR TITLE
Remove unrequired lines in getmodel output

### DIFF
--- a/src/getmodel/getmodel.cpp
+++ b/src/getmodel/getmodel.cpp
@@ -386,6 +386,9 @@ void getmodel::doResultsNoIntensityUncertainty(
       cumulative_prob += prob;
       _temp_results[result_index++].prob = cumulative_prob;
       //}
+
+      if (cumulative_prob > 0.999999940)
+        break; // single precision value approx 1
     }
 
     int num_results = result_index;

--- a/src/getmodel/getmodel.cpp
+++ b/src/getmodel/getmodel.cpp
@@ -381,11 +381,8 @@ void getmodel::doResultsNoIntensityUncertainty(
       OASIS_FLOAT prob = vulnerabilities[vulnerability_id][getVulnerabilityIndex(
           intensity_bin_index, damage_bin_index)];
 
-      // if (prob > 0 || damage_bin_index == 0)
-      //{
       cumulative_prob += prob;
       _temp_results[result_index++].prob = cumulative_prob;
-      //}
 
       if (cumulative_prob > 0.999999940)
         break; // single precision value approx 1


### PR DESCRIPTION
Introduce an escape condition in for loop to ensure that once cumulative probability reaches 1.0, later damage bin indexes are ignored in cases where footprint file does not have hazard intensity uncertainty. The output is now:

```
$ hexdump ./static/footprint.bin.z | head -1
0000000 003a 0000 0000 0000 9c78 cd4d 2eb9 6184
$ echo 1139 | evetobin -n | getmodel | cdftocsv | head -13
event_id,areaperil_id,vulnerability_id,bin_index,prob_to,bin_mean
1139,36,2,1,0.638000,0.000000
1139,36,2,2,0.814000,0.050000
1139,36,2,3,0.902000,0.150000
1139,36,2,4,0.955000,0.250000
1139,36,2,5,0.996000,0.350000
1139,36,2,6,1.000000,0.450000
1139,36,5,1,0.638000,0.000000
1139,36,5,2,0.814000,0.050000
1139,36,5,3,0.902000,0.150000
1139,36,5,4,0.955000,0.250000
1139,36,5,5,0.996000,0.350000
1139,36,5,6,1.000000,0.450000
```