### PR TITLE
Reduce memory footprint of leccalc and ordleccalc

### DIFF
--- a/src/aalcalc/summaryindex.cpp
+++ b/src/aalcalc/summaryindex.cpp
@@ -50,12 +50,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #include <map>
 
 
-
-struct summary_keyz {
-	int summary_id;
-	int fileindex;
-};
-
 bool operator<(const summary_keyz& lhs, const summary_keyz& rhs)
 {
 	if (lhs.summary_id != rhs.summary_id) {

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -137,6 +137,11 @@ struct summarySampleslevelHeader {
 	OASIS_FLOAT expval;				// exposure value
 };
 
+struct summary_keyz {
+	int summary_id;
+	int fileindex;
+};
+
 struct gulSampleslevelRec {
 	int sidx;		// This has be stored for thresholds cannot be implied
 	OASIS_FLOAT loss;		// may want to cut down to singe this causes 4 byte padding for allignment

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -360,7 +360,7 @@ inline void aggreports::DoSetUp(int &eptype, int &eptype_tvar, int &epcalc,
   if (eptype == AEP) eptype_tvar = AEPTVAR;
   else if (eptype == OEP) eptype_tvar = OEPTVAR;
 
-  if (epcalc == MEANDR && eptHeader_ == true) {
+  if (epcalc == MEANDR && eptHeader_ == true && skipheader_ == false) {
     std::string fileHeader;
     if (ordFlag_) {
       fileHeader = "SummaryID,EPCalc,EPType,ReturnPeriod,Loss\n";
@@ -552,18 +552,20 @@ inline void aggreports::DoSetUpWheatsheaf(int &eptype, int &eptype_tvar,
   else if (eptype == OEP) eptype_tvar = OEPTVAR;
 
   std::string fileHeader;
-  if (ordFlag_ && pseptHeader_) {
-    fileHeader = "SummaryID,SampleID,EPType,ReturnPeriod,Loss\n";
-    pseptHeader_ = false;
-  } else if (!ordFlag_ && wheatSheaf_[eptype] == false) {
-    fileHeader = "summary_id,sidx,return_period,loss";
-    if (ensembletosidx_.size() > 0) fileHeader += ",ensemble_id";
-    fileHeader += "\n";
-    wheatSheaf_[eptype] = true;
-  }
-  for (std::vector<int>::const_iterator it = fileIDs.begin();
-       it != fileIDs.end(); ++it) {
-    fprintf(fout_[*it], "%s", fileHeader.c_str());
+  if (skipheader_ == false) {
+    if (ordFlag_ && pseptHeader_) {
+      fileHeader = "SummaryID,SampleID,EPType,ReturnPeriod,Loss\n";
+      pseptHeader_ = false;
+    } else if (!ordFlag_ && wheatSheaf_[eptype] == false) {
+      fileHeader = "summary_id,sidx,return_period,loss";
+      if (ensembletosidx_.size() > 0) fileHeader += ",ensemble_id";
+      fileHeader += "\n";
+      wheatSheaf_[eptype] = true;
+    }
+    for (std::vector<int>::const_iterator it = fileIDs.begin();
+	 it != fileIDs.end(); ++it) {
+      fprintf(fout_[*it], "%s", fileHeader.c_str());
+    }
   }
 
   if (ordFlag_) {

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -43,12 +43,12 @@ bool operator<(const wheatkey &lhs, const wheatkey &rhs) {
 }
 
 
-aggreports::aggreports(const int totalperiods, const int maxsummaryid,
+aggreports::aggreports(const int totalperiods, const std::set<int> &summaryids,
 		       std::vector<std::map<outkey2, OutLosses>> &out_loss,
 		       FILE **fout, const bool useReturnPeriodFile,
 		       const int samplesize, const bool skipheader,
 		       const bool *outputFlags, const bool ordFlag) :
-  totalperiods_(totalperiods), maxsummaryid_(maxsummaryid),
+  totalperiods_(totalperiods), summaryids_(summaryids),
   out_loss_(out_loss), fout_(fout), useReturnPeriodFile_(useReturnPeriodFile),
   samplesize_(samplesize), skipheader_(skipheader), outputFlags_(outputFlags),
   ordFlag_(ordFlag)
@@ -962,7 +962,7 @@ inline void aggreports::FillWheatsheafItems(const outkey2 key,
 
 inline void aggreports::FillWheatsheafItems(const outkey2 key,
 	std::map<wheatkey, lossvec2> &items, const OASIS_FLOAT loss,
-	std::vector<int> &maxPeriodNo,
+	std::map<int, int> &maxPeriodNo,
 	std::map<int, double> &unusedperiodstoweighting) {
 
   wheatkey wk;
@@ -1017,7 +1017,7 @@ void aggreports::WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 
   if (outputFlags_[handles[WHEATSHEAF_MEAN]] == false) return;
 
-  std::vector<size_t> maxCount(maxsummaryid_+1, 0);
+  std::map<int, size_t> maxCount;
   for (auto x : items) {
     if (x.second.size() > maxCount[x.first.summary_id]) {
       maxCount[x.first.summary_id] = x.second.size();
@@ -1025,8 +1025,9 @@ void aggreports::WheatsheafAndWheatsheafMean(const std::vector<int> handles,
   }
 
   std::map<int, lossvec> mean_map;
-  for (int i = 1; i <= maxsummaryid_; i++) {
-    mean_map[i] = lossvec(maxCount[i], 0);
+  for (std::set<int>::iterator it = summaryids_.begin();
+       it != summaryids_.end(); ++it) {
+    mean_map[*it] = lossvec(maxCount[*it], 0);
   }
 
   for (auto s : items) {
@@ -1055,7 +1056,7 @@ void aggreports::WheatsheafAndWheatsheafMeanWithWeighting(
 
   std::map<wheatkey, lossvec2> items;
   int samplesize;
-  std::vector<int> maxPeriodNo(maxsummaryid_+1, 0);
+  std::map<int, int> maxPeriodNo;
   std::map<int, double> unusedperiodstoweighting = periodstoweighting_;
 
   if (ensemble_id != 0) {
@@ -1086,8 +1087,9 @@ void aggreports::WheatsheafAndWheatsheafMeanWithWeighting(
   if (outputFlags_[handles[WHEATSHEAF_MEAN]] == false) return;
 
   std::map<int, lossvec2> mean_map;
-  for (int i = 1; i <= maxsummaryid_; i++) {
-    mean_map[i] = lossvec2(maxPeriodNo[i], lossval());
+  for (std::set<int>::iterator it = summaryids_.begin();
+       it != summaryids_.end(); ++it) {
+    mean_map[*it] = lossvec2(maxPeriodNo[*it], lossval());
   }
 
   for (auto s : items) {

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -39,6 +39,7 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #define AGGREPORTS_H_
 
 #include <map>
+#include <set>
 #include <vector>
 #include "leccalc.h"
 
@@ -57,7 +58,7 @@ struct line_points{
 class aggreports {
 private:
 	const int totalperiods_;
-	const int maxsummaryid_;
+	const std::set<int> summaryids_;
 	std::vector<std::map<outkey2, OutLosses>> &out_loss_;
 	const bool *outputFlags_;
 	FILE **fout_;
@@ -170,7 +171,7 @@ private:
 	inline void FillWheatsheafItems(const outkey2 key,
 					std::map<wheatkey, lossvec2> &items,
 					const OASIS_FLOAT loss,
-					std::vector<int> &maxPeriodNo,
+					std::map<int, int> &maxPeriodNo,
 					std::map<int, double> &unusedperiodstoweighting);
 	void WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 					 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
@@ -188,7 +189,7 @@ private:
 				     const int eptype);
 
 public:
-	aggreports(const int totalperiods, const int maxsummaryid, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool skipheader, const bool *outputFlags, const bool ordFlag);
+	aggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool skipheader, const bool *outputFlags, const bool ordFlag);
 	void OutputAggMeanDamageRatio();
 	void OutputOccMeanDamageRatio();
 	void OutputAggFullUncertainty();

--- a/src/leccalc/leccalc.cpp
+++ b/src/leccalc/leccalc.cpp
@@ -54,6 +54,7 @@ This process will then read all the *.bin files in the subdirectory and then com
 #include <math.h>
 #include <vector>
 #include <map>
+#include <set>
 #include "leccalc.h"
 #include "aggreports.h"
 
@@ -78,6 +79,15 @@ bool operator<(const outkey2& lhs, const outkey2& rhs)
 	}
 	else {
 		return lhs.summary_id < rhs.summary_id;
+	}
+}
+
+bool operator<(const summary_keyz& lhs, const summary_keyz& rhs)
+{
+	if (lhs.summary_id != rhs.summary_id) {
+		return lhs.summary_id < rhs.summary_id;
+	} else {
+		return lhs.fileindex < rhs.fileindex;
 	}
 }
 
@@ -126,22 +136,18 @@ namespace leccalc {
 	}
 
 
-	void processinputfile(
-		unsigned int& samplesize,
-		const std::map<int, std::vector<int> >& event_to_periods,
-		int& maxsummaryid,
-		std::vector<std::map<outkey2, OutLosses>> &out_loss)
+	inline void checkinputfile(unsigned int& samplesize, FILE * fin)
 	{
 		// read_stream_type()
 		unsigned int stream_type = 0;
-		size_t i = fread(&stream_type, sizeof(stream_type), 1, stdin);
+		size_t i = fread(&stream_type, sizeof(stream_type), 1, fin);
 		if (i != 1 || isSummaryCalcStream(stream_type) != true) {
 			std::cerr << "FATAL:: Not a summarycalc stream invalid stream type: " << stream_type << "\n";
 			exit(-1);
 		}
 
 		// read_sample_size()
-		i = fread(&samplesize, sizeof(samplesize), 1, stdin);
+		i = fread(&samplesize, sizeof(samplesize), 1, fin);
 		if (i != 1) {
 			std::cerr << "FATAL: Stream read error: samplesize\n";
 			exit(-1);
@@ -149,13 +155,24 @@ namespace leccalc {
 
 		// read_summary_set_id()
 		unsigned int summaryset_id;
-		i = fread(&summaryset_id, sizeof(summaryset_id), 1, stdin);
+		i = fread(&summaryset_id, sizeof(summaryset_id), 1, fin);
 		if (i != 1) {
 			std::cerr << "FATAL: Stream read error: summaryset_id\n";
 			exit(-1);
 		}
+	}
+
+
+	void processinputfile(
+		unsigned int& samplesize,
+		const std::map<int, std::vector<int> >& event_to_periods,
+		std::set<int> &summaryids,
+		std::vector<std::map<outkey2, OutLosses>> &out_loss)
+	{
+		checkinputfile(samplesize, stdin);
 
 		// read_event()
+		size_t i = 1;
 		while (i != 0) {
 			summarySampleslevelHeader sh;
 			i = fread(&sh, sizeof(sh), 1, stdin);
@@ -176,10 +193,7 @@ namespace leccalc {
 				continue;
 			}
 
-			if (maxsummaryid < sh.summary_id)
-			{
-				maxsummaryid = sh.summary_id;
-			}
+			summaryids.insert(sh.summary_id);
 
 			// read_samples_and_compute_lec()
 			while (i != 0) {
@@ -210,7 +224,22 @@ namespace leccalc {
 
 	}
 
-	void doit(const std::string &subfolder, FILE **fout, const bool useReturnPeriodFile, const bool skipheader, bool *outputFlags, bool ordFlag)
+	inline void outputaggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss,
+				     FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool skipheader,
+				     const bool *outputFlags, const bool ordFlag)
+	{
+		aggreports agg(totalperiods, summaryids, out_loss, fout, useReturnPeriodFile, samplesize, skipheader, outputFlags, ordFlag);
+		agg.OutputOccMeanDamageRatio();
+		agg.OutputAggMeanDamageRatio();
+		agg.OutputOccFullUncertainty();
+		agg.OutputAggFullUncertainty();
+		agg.OutputOccWheatsheafAndWheatsheafMean();
+		agg.OutputAggWheatsheafAndWheatsheafMean();
+		agg.OutputOccSampleMean();
+		agg.OutputAggSampleMean();
+	}
+
+	void doit(const std::string &subfolder, FILE **fout, const bool useReturnPeriodFile, bool skipheader, bool *outputFlags, bool ordFlag)
 	{
 		std::string path = "work/" + subfolder;
 		if (path.substr(path.length() - 1, 1) != "/") {
@@ -221,13 +250,23 @@ namespace leccalc {
 		loadoccurence(event_to_periods, totalperiods);
 		std::vector<std::map<outkey2, OutLosses>> out_loss(2);
 
-
+		std::vector<std::string> files;
+		std::vector<FILE*> fileHandles;
+		std::vector<std::string> indexFiles;
 		unsigned int samplesize=0;
-		int maxsummaryid = -1;
+		std::set<int> summaryids;
 		if (subfolder.size() == 0) {
-			processinputfile(samplesize, event_to_periods, maxsummaryid, out_loss);
-		}
-		else {
+			processinputfile(samplesize, event_to_periods, summaryids, out_loss);
+			outputaggreports(totalperiods, summaryids, out_loss, fout, useReturnPeriodFile, samplesize, skipheader, outputFlags, ordFlag);
+			return;
+		} else {
+			// Store order of input files for future reference
+			std::string fileList = path + "filelist.idx";
+			FILE * flist = fopen(fileList.c_str(), "w");
+			if (flist == nullptr) {
+				fprintf(stderr, "FATAL: Cannot open %s\n", fileList.c_str());
+				exit(EXIT_FAILURE);
+			}
 			DIR* dir;
 			struct dirent* ent;
 			if ((dir = opendir(path.c_str())) != NULL) {
@@ -235,8 +274,23 @@ namespace leccalc {
 					std::string s = ent->d_name;
 					if (s.length() > 4 && s.substr(s.length() - 4, 4) == ".bin") {
 						s = path + ent->d_name;
-						setinputstream(s);
-						processinputfile(samplesize, event_to_periods, maxsummaryid, out_loss);
+						FILE * in = fopen(s.c_str(), "rb");
+						if (in != nullptr) {
+							checkinputfile(samplesize, in);
+						} else {
+							fprintf(stderr, "FATAL: Cannot open %s\n", s.c_str());
+							exit(EXIT_FAILURE);
+						}
+						files.push_back(s);   // Build input file list
+						fileHandles.push_back(in);
+						fprintf(flist, "%s\n", s.c_str());
+						// Check for index file
+						s.erase(s.length() - 4);
+						s += ".idx";
+						FILE * fidx = fopen(s.c_str(), "r");
+						if (fidx == nullptr) continue;
+						indexFiles.push_back(s);
+						fclose(fidx);
 					}
 				}
 			}
@@ -244,18 +298,103 @@ namespace leccalc {
 				fprintf(stderr, "FATAL: Unable to open directory %s\n", path.c_str());
 				exit(-1);
 			}
+			fclose(flist);
 		}
 
-		aggreports agg(totalperiods, maxsummaryid, out_loss, fout, useReturnPeriodFile, samplesize, skipheader, outputFlags, ordFlag);
-		agg.OutputOccMeanDamageRatio();
-		agg.OutputAggMeanDamageRatio();
-		agg.OutputOccFullUncertainty();
-		agg.OutputAggFullUncertainty();
-		agg.OutputOccWheatsheafAndWheatsheafMean();
-		agg.OutputAggWheatsheafAndWheatsheafMean();
-		agg.OutputOccSampleMean();
-		agg.OutputAggSampleMean();
+		if (files.size() == indexFiles.size()) {
+			// Combine summary index files into one master summary index file
+			int file_index = 0;
+			char line[4096];
+			std::map<summary_keyz, std::vector<long long>> summary_file_to_offset;
+			for (std::vector<std::string>::iterator it = indexFiles.begin(); it != indexFiles.end(); ++it) {
+				FILE * fidx = fopen(it->c_str(), "r");
+				summary_keyz summaryFile;
+				summaryFile.fileindex = file_index++;
+				while (fgets(line, sizeof(line), fidx) != 0) {
+					long long offset;
+					int ret = sscanf(line, "%d,%lld", &summaryFile.summary_id, &offset);
+					if (ret != 2) {
+						fprintf(stderr, "FATAL: Invalid data in file %s:\n%s",
+							it->c_str(), line);
+						exit(-1);
+					}
+					summary_file_to_offset[summaryFile].push_back(offset);
+				}
+				fclose(fidx);
+			}
+			std::string summaryFile = path + "summaries.idx";
+			FILE * fsummaries = fopen(summaryFile.c_str(), "w");
+			if (fsummaries == nullptr) {
+				fprintf(stderr, "Cannot open %s\n", summaryFile.c_str());
+				exit(EXIT_FAILURE);
+			}
+			for (std::map<summary_keyz, std::vector<long long>>::iterator it_s = summary_file_to_offset.begin();
+			     it_s != summary_file_to_offset.end(); ++it_s) {
+				for(std::vector<long long>::iterator it_v = it_s->second.begin(); it_v != it_s->second.end(); ++it_v) {
+					fprintf(fsummaries, "%d,%d,%lld\n", it_s->first.summary_id, it_s->first.fileindex, *it_v);
+				}
+			}
+			summary_file_to_offset.clear();   // Recover memory
+			fclose(fsummaries);
 
+			// Read input files by summary ID using master summary index file
+			int summary_id;
+			file_index = 0;
+			long long file_offset;
+			int last_summary_id = -1;
+			int last_file_index = -1;
+			FILE * fidx = fopen(summaryFile.c_str(), "r");
+			FILE * summary_fin = nullptr;
+			while (fgets(line, sizeof(line), fidx) != 0) {
+				int ret = sscanf(line, "%d,%d,%lld", &summary_id, &file_index, &file_offset);
+				if (ret != 3) {
+					fprintf(stderr, "FATAL: Invalid data in file %s:\n%s", summaryFile.c_str(), line);
+					exit(-1);
+				}
+				if (last_summary_id != summary_id) {
+					if (last_summary_id != -1) {
+						summaryids.clear();
+						summaryids.insert(last_summary_id);
+						outputaggreports(totalperiods, summaryids, out_loss, fout, useReturnPeriodFile, samplesize, skipheader, outputFlags, ordFlag);
+						out_loss = std::vector<std::map<outkey2, OutLosses>>(2);   // Reset
+						skipheader = true;   // Only print header for first summary ID if requested
+					}
+					last_summary_id = summary_id;
+				}
+				if (last_file_index != file_index) {
+					summary_fin = fileHandles[file_index];
+					last_file_index = file_index;
+				}
+				if (summary_fin != nullptr) {
+					std::vector<sampleslevelRec> vrec;
+					flseek(summary_fin, file_offset, SEEK_SET);
+					summarySampleslevelHeader sh;
+					size_t i = fread(&sh, sizeof(sh), 1, summary_fin);
+					std::map<int, std::vector<int> >::const_iterator iter = event_to_periods.find(sh.event_id);
+					if (iter == event_to_periods.end()) continue;   // Event not found so don't process it
+					while (i != 0) {
+						sampleslevelRec sr;
+						i = fread(&sr, sizeof(sr), 1, summary_fin);
+						if (i != 1 || sr.sidx == 0) break;
+						dolecoutputaggsummary(sh.summary_id, sr.sidx, sr.loss, iter->second, out_loss);
+					}
+				}
+			}
+			summaryids.clear();
+			summaryids.insert(last_summary_id);
+			outputaggreports(totalperiods, summaryids, out_loss, fout, useReturnPeriodFile, samplesize, skipheader, outputFlags, ordFlag);
+		} else {
+			if (indexFiles.size() > 0) {
+				fprintf(stderr, "%d summary index files missing: "
+						"Ignoring summary index files.\n",
+					(int)indexFiles.size() - (int)files.size());
+			}
+			for (std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it) {
+				setinputstream(*it);
+				processinputfile(samplesize, event_to_periods, summaryids, out_loss);
+			}
+			outputaggreports(totalperiods, summaryids, out_loss, fout, useReturnPeriodFile, samplesize, skipheader, outputFlags, ordFlag);
+		}
 	}
 
 }

--- a/src/leccalc/main.cpp
+++ b/src/leccalc/main.cpp
@@ -63,8 +63,7 @@ void segfault_sigaction(int, siginfo_t *si, void *) {
 #endif
 
 namespace leccalc {
-//	void doit(const std::string& subfolder, FILE** fout, bool useReturnPeriodFile, bool skipheader, FILE** ord_out);
-	void doit(const std::string &subfolder, FILE** fout, const bool useReturnPeriodFile, const bool skipheader, bool *outputFlags, bool ordFlag);
+	void doit(const std::string &subfolder, FILE** fout, const bool useReturnPeriodFile, bool skipheader, bool *outputFlags, bool ordFlag);
 }
 
 
@@ -107,13 +106,6 @@ int main(int argc, char* argv[])
 	bool outputFlags[8] = { false, false, false, false,
 				false, false, false, false };
 	const bool ordFlag = false;   // Turn off ORD output
-
-/*	// Variables for ORD output
-	FILE* ord_out[] = { nullptr, nullptr };
-	bool ordOutput = false;
-	bool ept = false;
-	bool psept = false;
-	std::string ordStem;*/   // HC
 
 	std::string subfolder;
 	int opt;
@@ -180,19 +172,6 @@ int main(int argc, char* argv[])
 		help();
 	}
 
-/*	if (ordOutput) {
-		if (ept) {
-			std::string eptFilename = ordStem;
-			if (eptFilename != "-") eptFilename += "_ept.csv";
-			openpipe(EPT, eptFilename, ord_out);
-		}
-		if (psept) {
-			std::string pseptFilename = ordStem;
-			if (pseptFilename != "-") pseptFilename += "_psept.csv";
-			openpipe(PSEPT, pseptFilename, ord_out);
-		}
-	}*/   // HC
-
 	progname = argv[0];
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
 	struct sigaction sa;
@@ -207,10 +186,9 @@ int main(int argc, char* argv[])
 
 	try {
 		initstreams();
-        logprintf(progname, "INFO", "starting process..\n");
-//		leccalc::doit(subfolder, fout, useReturnPeriodFile, skipheader, ord_out);   // HC
-	leccalc::doit(subfolder, fout, useReturnPeriodFile, skipheader, outputFlags, ordFlag);
-        logprintf(progname, "INFO", "finishing process..\n");
+        	logprintf(progname, "INFO", "starting process..\n");
+		leccalc::doit(subfolder, fout, useReturnPeriodFile, skipheader, outputFlags, ordFlag);
+        	logprintf(progname, "INFO", "finishing process..\n");
 		return EXIT_SUCCESS;
 	}catch (std::bad_alloc&) {
 		fprintf(stderr, "FATAL: %s: Memory allocation failed\n", progname);

--- a/src/summarycalc/main.cpp
+++ b/src/summarycalc/main.cpp
@@ -75,6 +75,7 @@ void help()
 		"-c input stream = gul coverage\n"
 		"-i input stream = gul item\n"
 		"-p input path\n"
+		"-m reduce downstream memory use with index file(s)\n"
 		"-z output zeros\n"
 		"-[summarysetid] outfilepipe\n"
 		"where summarysetid range is 0 to 9\n"
@@ -92,10 +93,11 @@ int main(int argc, char* argv[])
 {
 	progname = argv[0];
 	int opt;
+	bool indexFile = false;
 	bool noneOutputTrue = true;
 	int truecount = 0;
 	summarycalc f;
-	while ((opt = getopt(argc, argv, "vzhcixfgp:0:1:2:3:4:5:6:7:8:9:")) != -1) {
+	while ((opt = getopt(argc, argv, "vzhcixfgmp:0:1:2:3:4:5:6:7:8:9:")) != -1) {
 		switch (opt) {
 		case 'g':
 			truecount++;
@@ -122,6 +124,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'p':
 			f.setinputpath(optarg);
+			break;
+		case 'm':
+			indexFile = true;
 			break;
 		case '0':
 		case '1':
@@ -157,6 +162,8 @@ int main(int argc, char* argv[])
 	}
 
 	if (noneOutputTrue) return EXIT_FAILURE; // no output stream so nothing to do...
+
+	if (indexFile) f.openindexfiles();
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
 	struct sigaction sa;

--- a/src/summarycalc/summarycalc.h
+++ b/src/summarycalc/summarycalc.h
@@ -61,6 +61,7 @@ private:
 	int min_summary_id_[MAX_SUMMARY_SETS] = { MAX_SUMMARY_ID ,MAX_SUMMARY_ID , MAX_SUMMARY_ID , MAX_SUMMARY_ID , MAX_SUMMARY_ID , MAX_SUMMARY_ID , MAX_SUMMARY_ID , MAX_SUMMARY_ID , MAX_SUMMARY_ID  ,MAX_SUMMARY_ID };  // min should be equal to one											  
 	int max_summary_id_[MAX_SUMMARY_SETS] = { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1 };
 	FILE *fout[MAX_SUMMARY_SETS] = { nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr };
+	FILE *idxout[MAX_SUMMARY_SETS] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 	coverage_id_or_output_id_to_Summary_id *co_to_s_[MAX_SUMMARY_SETS] = { nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr };
 	//output_id_to_Summary_id *o_to_s[MAX_SUMMARY_SETS] = { nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr };
 	loss_exp **sssl[MAX_SUMMARY_SETS] = { nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr }; // three dimensional array sssl[summary_set][summary_id][sidx] to loss exposure
@@ -72,6 +73,8 @@ private:
 	input_type inputtype_ = UNKNOWN;
 	std::string inputpath_;
 	bool zerooutput_ = false;
+	std::map<int, std::string> indexFiles;
+	long long offset_[MAX_SUMMARY_SETS] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };   // for index file
 // functions
 	void reset_sssl_array(int sample_size);
 	void alloc_sssl_array(int sample_size);
@@ -106,6 +109,7 @@ public:
 	void dofmsummary();
 	void doit();
 	void openpipe(int summary_id, const std::string &pipe);
+	void openindexfiles();
 	void setgulcoveragemode() { inputtype_ = GUL_COVERAGE_STREAM; };
 	void setgulitemmode() { inputtype_ = GUL_ITEM_STREAM; };
 	void setgulitemxmode() { inputtype_ = GUL_ITEMX_STREAM; };

--- a/src/summaryindex/summaryindex.cpp
+++ b/src/summaryindex/summaryindex.cpp
@@ -50,12 +50,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #include <map>
 
 
-
-struct summary_keyz {
-	int summary_id;
-	int fileindex;
-};
-
 bool operator<(const summary_keyz& lhs, const summary_keyz& rhs)
 {
 	if (lhs.summary_id != rhs.summary_id) {


### PR DESCRIPTION
<!--start_release_notes-->
### Reduce memory footprint of leccalc and ordleccalc
`leccalc` and `ordleccalc` use a lot of memory when granular outputs with a high number of samples are requested. To reduce the memory footprint, summary index files can be produced with the `-m` option. For example:
```
$ summarycalc -i -m -1 summarycalcoutput.bin
```
will create the summary index file `summarycalcoutput.idx`.

`leccalc` and `ordleccalc` detect the presence of these files in the work directory. If all `summarycalc` output binary files have a corresponding index file, the index files are collated and a master `summaries.idx` file is produced. The `summaries.idx` file features three columns: summary ID; binary file index; and position relative to start of binary file (offset). Additionally, a list of binary files in the order in which they have been indexed (`filelist.idx`) is created for the purposes of debugging. The file `filelist.idx` is not required by `leccalc` or `ordleccalc`. Each summary ID is processed individually.

In the case where some or all summary index files are missing, `leccalc` and `ordleccalc` fall back to their default behaviour where all summary IDs are processed at the same time. This option is more memory intensive, but may be faster.
<!--end_release_notes-->