### PR TITLE
Change ensemble.bin directory and drop sample_id column

### DIFF
--- a/src/ensembletobin/ensembletobin.cpp
+++ b/src/ensembletobin/ensembletobin.cpp
@@ -22,8 +22,7 @@ namespace ensembletobin {
 
     // Read data
     while(fgets(line, sizeof(line), stdin) != 0) {
-      if (sscanf(line, "%d,%d,%d", &q.sidx, &q.ensemble_id, &q.sample_id) != 3)
-      {
+      if (sscanf(line, "%d,%d", &q.sidx, &q.ensemble_id) != 2) {
 
 	fprintf(stderr, "FATAL: Invalid data in line %d:\n%s", lineno, line);
 	return;
@@ -33,9 +32,7 @@ namespace ensembletobin {
 	fwrite(&q, sizeof(q), 1, stdout);
 
       }
-
       lineno++;
-
     }
 
   }

--- a/src/ensembletocsv/ensembletocsv.cpp
+++ b/src/ensembletocsv/ensembletocsv.cpp
@@ -14,12 +14,12 @@ namespace ensembletocsv {
 
   void doit() {
 
-    printf("sidx, ensemble_id, sample_id\n");
+    printf("sidx, ensemble_id\n");
 
     Ensemble q;
     size_t i = fread(&q, sizeof(q), 1, stdin);
     while (i != 0) {
-      printf("%d, %d, %d\n", q.sidx, q.ensemble_id, q.sample_id);
+      printf("%d, %d\n", q.sidx, q.ensemble_id);
       i = fread(&q, sizeof(q), 1, stdin);
     }
 

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -409,6 +409,7 @@ inline  void logprintf(const std::string &program_name,const std::string &msgtyp
 #define RETURNPERIODS_FILE "input/returnperiods.bin"
 #define OCCURRENCE_FILE "input/occurrence.bin"
 #define PERIODS_FILE "input/periods.bin"		// period to weighting mapping
+#define ENSEMBLE_FILE "input/ensemble.bin"
 
 #define DAMAGE_BIN_DICT_FILE "static/damage_bin_dict.bin"
 #define DAMAGE_CDF_BIN_FILE "static/damage_cdf.bin"
@@ -419,7 +420,6 @@ inline  void logprintf(const std::string &program_name,const std::string &msgtyp
 // compressed variant of vulnerabilities
 #define ZVULNERABILITY_FILE "static/vulnerability.bin.z"
 #define ZVULNERABILITY_IDX_FILE "static/vulnerability.idx.z"
-#define ENSEMBLE_FILE "static/ensemble.bin"
 #define FOOTPRINT_FILE  "static/footprint.bin"
 #define FOOTPRINT_IDX_FILE  "static/footprint.idx"
 // compressed variant of footprint

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -321,7 +321,6 @@ struct Ensemble
 {
 	int sidx;
 	int ensemble_id;
-	int sample_id;
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
<!--start_release_notes-->
### Change ensemble.bin directory and drop sample_id column
The `ensemble.bin` file defines the mappings between sample IDs and ensemble IDs. Both `aalcalc` and `leccalc` now search for this file in the `input/` directory. This has been changed as the file is not a property of the model and can vary between runs, meaning the `input/` directory is a more appropriate location. This also allows for the file to be created dynamically in the complex model wrapper.

The `ensemble.bin` file now contains two columns: `sidx` and `ensemble_id`. Both `aalcalc` and `leccalc` deduce cases where an ensemble consists of multiple samples without using the `sample_id` column. Therefore, this column has been dropped as it is unnecessary. `ensembletobin` will convert the new two-column and legacy three-column `ensemble.csv` files to binary format.
<!--end_release_notes-->