### PR TITLE
Define preprocessor macro to set precision of OASIS_FLOAT

### DIFF
--- a/src/crossvalidation/crossvalidation.cpp
+++ b/src/crossvalidation/crossvalidation.cpp
@@ -43,8 +43,13 @@ namespace crossvalidation {
     damageBins.clear();
     while(fgets(line, sizeof(line), damagebinFile) != 0) {
 
-      if(sscanf(line, "%d,%f,%f,%f,%d", &d.bin_index, &d.bin_from, &d.bin_to,
-		&d.interpolation, &d.interval_type) != 5) {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%lf,%lf,%lf,%d", &d.bin_index, &d.bin_from,
+		&d.bin_to, &d.interpolation, &d.interval_type) != 5) {
+#else
+      if(sscanf(line, "%d,%f,%f,%f,%d", &d.bin_index, &d.bin_from,
+		&d.bin_to, &d.interpolation, &d.interval_type) != 5) {
+#endif
 
 	fprintf(stderr, "File %s\n", damagebinFileName);
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);
@@ -82,8 +87,13 @@ namespace crossvalidation {
     intensityBins.clear();
     while(fgets(line, sizeof(line), vulnerabilityFile) != 0) {
 
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%d,%d,%lf", &v.vulnerability_id, &v.intensity_bin_id,
+		&v.damage_bin_id, &v.probability) != 4) {
+#else
       if(sscanf(line, "%d,%d,%d,%f", &v.vulnerability_id, &v.intensity_bin_id,
 		&v.damage_bin_id, &v.probability) != 4) {
+#endif
 
 	fprintf(stderr, "File %s\n", vulnerabilityFileName);
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);
@@ -129,11 +139,21 @@ namespace crossvalidation {
     while(fgets(line, sizeof(line), footprintFile) != 0) {
 
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+  #ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%llu,%d,%lf", &f.event_id, &f.areaperil_id,
+		&f.intensity_bin_id, &f.probability) != 4) {
+  #else
       if(sscanf(line, "%d,%llu,%d,%f", &f.event_id, &f.areaperil_id,
 		&f.intensity_bin_id, &f.probability) != 4) {
+  #endif
 #else
+  #ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%u,%d,%lf", &f.event_id, &f.areaperil_id,
+		&f.intensity_bin_id, &f.probability) != 4) {
+  #else
       if(sscanf(line, "%d,%u,%d,%f", &f.event_id, &f.areaperil_id,
 		&f.intensity_bin_id, &f.probability) != 4) {
+  #endif
 #endif
 
 	fprintf(stderr, "File %s\n", footprintFileName);

--- a/src/fmprofiletobin/fmprofiletobin.cpp
+++ b/src/fmprofiletobin/fmprofiletobin.cpp
@@ -55,12 +55,22 @@ namespace fmprofiletobin {
 		fgets(line, sizeof(line), stdin);	// skip header
 		lineno++;
 		while (fgets(line, sizeof(line), stdin) != 0) {
-			if (sscanf(line, "%d,%d,%f,%f,%f,%f,%f,%f,%f,%f,%d,%f,%f,%f,%f,%f,%f,%f", &q.profile_id,
-				&q.calcrule_id, &q.deductible1, &q.deductible2,
-                &q.deductible3, &q.attachment, &q.limit1, &q.share1,
-                &q.share2, &q.share3, &q.step_id, &q.trigger_start, &q.trigger_end,
-				&q.payout_start, &q.payout_end, &q.limit2,
-				&q.scale1, &q.scale2) != 18) {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+			if (sscanf(line, "%d,%d,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%d,%lf,%lf,%lf,%lf,%lf,%lf,%lf",
+				   &q.profile_id, &q.calcrule_id, &q.deductible1, &q.deductible2,
+				   &q.deductible3, &q.attachment, &q.limit1, &q.share1, &q.share2,
+				   &q.share3, &q.step_id, &q.trigger_start, &q.trigger_end,
+				   &q.payout_start, &q.payout_end, &q.limit2, &q.scale1,
+				   &q.scale2) != 18)
+#else
+			if (sscanf(line, "%d,%d,%f,%f,%f,%f,%f,%f,%f,%f,%d,%f,%f,%f,%f,%f,%f,%f",
+				   &q.profile_id, &q.calcrule_id, &q.deductible1, &q.deductible2,
+				   &q.deductible3, &q.attachment, &q.limit1, &q.share1, &q.share2,
+				   &q.share3, &q.step_id, &q.trigger_start, &q.trigger_end,
+				   &q.payout_start, &q.payout_end, &q.limit2, &q.scale1,
+				   &q.scale2) != 18)
+#endif
+			{
 				fprintf(stderr, "FATAL: Invalid data in line %d:\n%s", lineno, line);
 				return;
 			}
@@ -81,10 +91,17 @@ namespace fmprofiletobin {
         fgets(line, sizeof(line), stdin);  // skip header
         lineno++;
         while (fgets(line, sizeof(line), stdin) != 0) {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+            if (sscanf(line, "%d,%d,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf", &q.profile_id,
+                       &q.calcrule_id, &q.deductible1, &q.deductible2,
+                       &q.deductible3, &q.attachment, &q.limit, &q.share1,
+                       &q.share2, &q.share3) != 10) {
+#else
             if (sscanf(line, "%d,%d,%f,%f,%f,%f,%f,%f,%f,%f", &q.profile_id,
                        &q.calcrule_id, &q.deductible1, &q.deductible2,
                        &q.deductible3, &q.attachment, &q.limit, &q.share1,
                        &q.share2, &q.share3) != 10) {
+#endif
                 fprintf(stderr, "FATAL: Invalid data in line %d:\n%s", lineno, line);
                 return;
             } else {

--- a/src/gultobin/gultobin.cpp
+++ b/src/gultobin/gultobin.cpp
@@ -68,7 +68,11 @@ namespace gultobin {
 		gh.event_id = -1;
 		while (fgets(line, sizeof(line), stdin) != 0)
 		{
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+			if (sscanf(line, "%d,%d,%d,%lf", &q.event_id, &q.item_id, &q.sidx, &q.loss) != 4) {
+#else
 			if (sscanf(line, "%d,%d,%d,%f", &q.event_id, &q.item_id, &q.sidx, &q.loss) != 4) {
+#endif
 				fprintf(stderr, "FATAL: Invalid data in line %d:\n%s", lineno, line);
 				return;
 			}

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -66,7 +66,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 // Slowly where applicable we will replace int and OASIS_FLOAT references with
 // OASIS_INT and OASIS_FLOAT so its easy to change the size of the streams 
 typedef int32_t OASIS_INT ;
-//typedef float OASIS_FLOAT;   // HC
 
 // #define OASIS_FLOAT_TYPE_DOUBLE
 #ifdef OASIS_FLOAT_TYPE_DOUBLE

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -66,7 +66,14 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 // Slowly where applicable we will replace int and OASIS_FLOAT references with
 // OASIS_INT and OASIS_FLOAT so its easy to change the size of the streams 
 typedef int32_t OASIS_INT ;
+//typedef float OASIS_FLOAT;   // HC
+
+// #define OASIS_FLOAT_TYPE_DOUBLE
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+typedef double OASIS_FLOAT;
+#else
 typedef float OASIS_FLOAT;
+#endif
 
 // #define AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG

--- a/src/kat/kat.cpp
+++ b/src/kat/kat.cpp
@@ -82,7 +82,11 @@ namespace kat {
 					eOut[*it].event_id = 0;
 					break;
 				}
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+				inArgs = sscanf(line, "%d,%d,%d,%lf,%lf,%lf", &eOut[*it].summary_id, &eOut[*it].type, &eOut[*it].event_id, &eOut[*it].mean, &eOut[*it].standard_deviation, &eOut[*it].exposure_value);
+#else
 				inArgs = sscanf(line, "%d,%d,%d,%f,%f,%f", &eOut[*it].summary_id, &eOut[*it].type, &eOut[*it].event_id, &eOut[*it].mean, &eOut[*it].standard_deviation, &eOut[*it].exposure_value);
+#endif
 				if (inArgs == 0)   // Print header
 					fprintf(stdout, "%s", line);
 				else if (inArgs != 6) {   // Check file is valid
@@ -120,7 +124,11 @@ namespace kat {
 							it--;
 							break;
 						} else {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+							sscanf(line, "%d,%d,%d,%lf,%lf,%lf", &e->summary_id, &e->type, &e->event_id, &e->mean, &e->standard_deviation, &e->exposure_value);
+#else
 							sscanf(line, "%d,%d,%d,%f,%f,%f", &e->summary_id, &e->type, &e->event_id, &e->mean, &e->standard_deviation, &e->exposure_value);
+#endif
 						}
 						currentEventID = e->event_id;
 					} while (currentEventID <= expectedEventID);

--- a/src/randtobin/randtobin.cpp
+++ b/src/randtobin/randtobin.cpp
@@ -56,7 +56,11 @@ void doit()
 	fgets(line, sizeof(line), stdin);	// skip first line
     while (fgets(line, sizeof(line), stdin) != 0)
     {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+       if (sscanf(line, "%lf", &randno) != 1) {
+#else
        if (sscanf(line, "%f", &randno) != 1){
+#endif
            fprintf(stderr, "FATAL: Invalid data in line %d:\n%s", lineno, line);
            return;
        }

--- a/src/summarycalctobin/summarycalctobin.cpp
+++ b/src/summarycalctobin/summarycalctobin.cpp
@@ -66,7 +66,11 @@ void doit(int maxsampleindex)
   fwrite(&summarystreamid, sizeof(int), 1, stdout);
     while (fgets(line, sizeof(line), stdin) != 0)
     {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if (sscanf(line, "%d,%lf,%d,%d,%lf", &sh.event_id, &sh.expval, &sh.summary_id, &sr.sidx,&sr.loss) != 5){
+#else
       if (sscanf(line, "%d,%f,%d,%d,%f", &sh.event_id, &sh.expval, &sh.summary_id, &sr.sidx,&sr.loss) != 5){
+#endif
            fprintf(stderr, "FATAL: Invalid data in line %d:\n%s", lineno, line);
            return;
        }

--- a/src/validatedamagebin/validatedamagebin.cpp
+++ b/src/validatedamagebin/validatedamagebin.cpp
@@ -52,8 +52,13 @@ namespace validatedamagebin {
     bool newFormat;
     if (fgets(line, sizeof(line), stdin) != 0) {
       // Deprecated format
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if (sscanf(line, "%d,%lf,%lf,%lf,%d", &p.bin_index, &p.bin_from, &p.bin_to,
+		 &p.interpolation, &p.interval_type) == 5) {
+#else
       if (sscanf(line, "%d,%f,%f,%f,%d", &p.bin_index, &p.bin_from, &p.bin_to,
 		 &p.interpolation, &p.interval_type) == 5) {
+#endif
 
 	fprintf(stderr, "Deprecated format:"
 			" interval_type column no longer required.\n");
@@ -62,8 +67,13 @@ namespace validatedamagebin {
 
       }
       // New format
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      else if (sscanf(line, "%d,%lf,%lf,%lf", &p.bin_index, &p.bin_from, &p.bin_to,
+		      &p.interpolation) == 4) {
+#else
       else if (sscanf(line, "%d,%f,%f,%f", &p.bin_index, &p.bin_from, &p.bin_to,
 		      &p.interpolation) == 4) {
+#endif
 
 	p.interval_type = 0;
 	newFormat = true;
@@ -90,8 +100,13 @@ namespace validatedamagebin {
 
       bool furtherChecks = true;
 
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if (sscanf(line, "%d,%lf,%lf,%lf,%d", &q.bin_index, &q.bin_from, &q.bin_to,
+		 &q.interpolation, &q.interval_type) == 5) {
+#else
       if (sscanf(line, "%d,%f,%f,%f,%d", &q.bin_index, &q.bin_from, &q.bin_to,
 		 &q.interpolation, &q.interval_type) == 5) {
+#endif
 
 	if (newFormat) {
 	  fprintf(stderr, "Deprecated format used in line %d:\n%s\n",
@@ -99,8 +114,14 @@ namespace validatedamagebin {
 	  dataValid = false;
 	}
 
-      } else if (sscanf(line, "%d,%f,%f,%f", &q.bin_index, &q.bin_from,
+      }
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      else if (sscanf(line, "%d,%lf,%lf,%lf", &q.bin_index, &q.bin_from,
 			&q.bin_to, &q.interpolation) == 4) {
+#else
+      else if (sscanf(line, "%d,%f,%f,%f", &q.bin_index, &q.bin_from,
+			&q.bin_to, &q.interpolation) == 4) {
+#endif
 
 	if (!newFormat) {
 	  fprintf(stderr, "Missing interval_type column in line %d:\n%s\n",

--- a/src/validatefootprint/validatefootprint.cpp
+++ b/src/validatefootprint/validatefootprint.cpp
@@ -79,11 +79,21 @@ namespace validatefootprint {
 
       // Check for invalid data
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
+  #ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%llu,%d,%lf", &q.event_id, &q.areaperil_id,
+		&q.intensity_bin_id, &q.probability) != 4) {
+  #else
       if(sscanf(line, "%d,%llu,%d,%f", &q.event_id, &q.areaperil_id,
 		&q.intensity_bin_id, &q.probability) != 4) {
+  #endif
 #else
+  #ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%u,%d,%lf", &q.event_id, &q.areaperil_id,
+		&q.intensity_bin_id, &q.probability) != 4) {
+  #else
       if(sscanf(line, "%d,%u,%d,%f", &q.event_id, &q.areaperil_id,
 		&q.intensity_bin_id, &q.probability) != 4) {
+  #endif
 #endif
 
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);

--- a/src/validateoasisfiles/validateoasisfiles.cpp
+++ b/src/validateoasisfiles/validateoasisfiles.cpp
@@ -286,10 +286,20 @@ namespace validateoasisfiles {
     lineno++;
     while(fgets(line, sizeof(line), fmprofileFile) != 0) {
 
-      if(sscanf(line, "%d,%d,%f,%f,%f,%f,%f,%f,%f,%f", &fmprof.profile_id,
-		&fmprof.calcrule_id, &fmprof.deductible1, &fmprof.deductible2,
-		&fmprof.deductible3, &fmprof.attachment, &fmprof.limit,
-		&fmprof.share1, &fmprof.share2, &fmprof.share3) != 10) {
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%d,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf",
+		&fmprof.profile_id, &fmprof.calcrule_id, &fmprof.deductible1,
+		&fmprof.deductible2, &fmprof.deductible3, &fmprof.attachment,
+		&fmprof.limit, &fmprof.share1, &fmprof.share2,
+		&fmprof.share3) != 10)
+#else
+      if(sscanf(line, "%d,%d,%f,%f,%f,%f,%f,%f,%f,%f",
+		&fmprof.profile_id, &fmprof.calcrule_id, &fmprof.deductible1,
+		&fmprof.deductible2, &fmprof.deductible3, &fmprof.attachment,
+		&fmprof.limit, &fmprof.share1, &fmprof.share2,
+		&fmprof.share3) != 10)
+#endif
+      {
 
 	fprintf(stderr, "File %s\n", fmprofilePath);
 	fprintf(stderr, "Invalid data in line %d:\n%s\n", lineno, line);

--- a/src/validatevulnerability/validatevulnerability.cpp
+++ b/src/validatevulnerability/validatevulnerability.cpp
@@ -80,8 +80,13 @@ namespace validatevulnerability {
     while(fgets(line, sizeof(line), stdin) != 0) {
 
       // Check for invalid data
+#ifdef OASIS_FLOAT_TYPE_DOUBLE
+      if(sscanf(line, "%d,%d,%d,%lf", &q.vulnerability_id, &q.intensity_bin_id,
+		&q.damage_bin_id, &q.probability) != 4) {
+#else
       if(sscanf(line, "%d,%d,%d,%f", &q.vulnerability_id, &q.intensity_bin_id,
 		&q.damage_bin_id, &q.probability) != 4) {
+#endif
 
 	fprintf(stderr, "Error: Invalid data in line %d:\n%s\n", lineno, line);
 	dataValid = false;


### PR DESCRIPTION
<!--start_release_notes-->
### Define preprocessor macro to set precision of OASIS_FLOAT
Increasing the precision of `OASIS_FLOAT` from a 4-byte `float` to an 8-byte `double` caused issues when reading in values of this type with the `%f` format specifier. The precision of `OASIS_FLOAT` can now be changed through the definition of the preprocessor macro `OASIS_FLOAT_TYPE_DOUBLE` in `include/oasis.h`. This results in the use of the `%lf` specifier in cases where `OASIS_FLOAT` acts an alias for a `double`.
<!--end_release_notes-->
