### PR TITLE
Add option to write Period Average Loss Table (PALT) with aalcalc

### DIFF
--- a/src/aalcalc/aalcalc.cpp
+++ b/src/aalcalc/aalcalc.cpp
@@ -51,6 +51,10 @@ void aalcalc::loadensemblemapping()
 {
 	FILE *fin = fopen(ENSEMBLE_FILE, "rb");
 	if (fin == NULL) return;
+	if (ord_output_ == true) {
+		fprintf(stderr, "WARNING: ensembles not compatible with ORD format. Ignoring ensemble file.\n");
+		return;
+	}
 
 	Ensemble e;
 	sidxtoensemble_.resize(samplesize_ + 1, 0);
@@ -503,8 +507,12 @@ void aalcalc::outputresultscsv_new(std::vector<aal_rec>& vec_aal, int periods,in
 void aalcalc::outputresultscsv_new()
 {
 	if (skipheader_ == false) {
-		printf("summary_id,type,mean,standard_deviation,exposure_value");
-		if (sidxtoensemble_.size() > 0) printf(",ensemble_id");
+		if (ord_output_ == true) {
+			printf("SummaryID,SampleType,MeanLoss,SDLoss,SourceExposure");
+		} else {
+			printf("summary_id,type,mean,standard_deviation,exposure_value");
+			if (sidxtoensemble_.size() > 0) printf(",ensemble_id");
+		}
 		printf("\n");
 	}
 

--- a/src/aalcalc/aalcalc.h
+++ b/src/aalcalc/aalcalc.h
@@ -101,6 +101,7 @@ private:
 	std::vector<int> sidxtoensemble_;
 	std::vector<int> ensemblecount_;
 	bool skipheader_ = false;
+	bool ord_output_ = false;
 // private functions
 	void loadoccurrence();
 	void indexevents(const std::string& fullfilename, std::string& filename);
@@ -128,7 +129,7 @@ private:
 	inline void outputrows(const char * buffer, int strLen);
 	void getmaxsummaryid(std::string& path);
 public:
-	aalcalc(bool skipheader) : skipheader_(skipheader) {};
+	aalcalc(bool skipheader, bool ord_output) : skipheader_(skipheader), ord_output_(ord_output) {};
 	void doit(const std::string& subfolder);		// experimental
 	void debug(const std::string &subfolder);
 };

--- a/src/aalcalc/main.cpp
+++ b/src/aalcalc/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[])
 	bool debug = false;
 	bool skipheader = false;
 	bool ord_output = false;
-	while ((opt = getopt(argc, argv, (char *)"swvdhK:")) != -1) {
+	while ((opt = getopt(argc, argv, (char *)"swvdohK:")) != -1) {
 		switch (opt) {
 		case 'v':
 			fprintf(stderr, "%s : version: %s\n", argv[0], VERSION);

--- a/src/aalcalc/main.cpp
+++ b/src/aalcalc/main.cpp
@@ -25,6 +25,8 @@ void segfault_sigaction(int, siginfo_t *si, void *)
 void help()
 {
 	fprintf(stderr, "-K workspace sub folder\n");
+	fprintf(stderr, "-o Open Results Data (ORD) output\n");
+	fprintf(stderr, "-s skip header\n");
 	fprintf(stderr, "-v version\n");
 	fprintf(stderr, "-h help\n");
 	
@@ -37,6 +39,7 @@ int main(int argc, char* argv[])
 	int opt;
 	bool debug = false;
 	bool skipheader = false;
+	bool ord_output = false;
 	while ((opt = getopt(argc, argv, (char *)"swvdhK:")) != -1) {
 		switch (opt) {
 		case 'v':
@@ -48,6 +51,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'K':
 			subfolder = optarg;
+			break;
+		case 'o':
+			ord_output = true;
 			break;
 		case 'd':
 			debug = true;			
@@ -79,7 +85,7 @@ int main(int argc, char* argv[])
 
 	
 	try {
-		aalcalc a(skipheader);
+		aalcalc a(skipheader, ord_output);
 		if (debug == true) {
 			a.debug(subfolder);
 		}


### PR DESCRIPTION
<!--start_release_notes-->
### Add option to write Period Average Loss Table (PALT) with aalcalc
An optional flag `-o` has been introduced to `aalcalc` to output the Period Average Loss Table (PALT):
```
$ aalcalc -K[output_directory_name] -o > aalcalc.csv
```
As ensembles are not compatible with ORD format at this time, the ensemble file is ignored if this flag is issued on the command line. `SourceNumLocs` is not currently supported as the required input files are not part of the ktools kernel.
<!--end_release_notes-->
