### PR TITLE
Add Validity Checks for Process Number and Total Processes Parameters in eve

### DIFF
--- a/src/eve/main.cpp
+++ b/src/eve/main.cpp
@@ -137,6 +137,15 @@ int main(int argc, char *argv[]) {
 
     OASIS_INT pno = atoi(argv[optind]);
     OASIS_INT total = atoi(argv[optind + 1]);
+    if (pno <= 0) {
+      fprintf(stderr, "FATAL:%s: Invalid value for processno supplied\n", progname);
+      parameter_error = true;
+    }
+    if (total <= 0) {
+      fprintf(stderr, "FATAL:%s: Invalid value for totalprocesses supplied\n", progname);
+      parameter_error = true;
+    }
+    if (parameter_error) exit(EXIT_FAILURE);
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
     struct sigaction sa;

--- a/src/eve/main.cpp
+++ b/src/eve/main.cpp
@@ -138,11 +138,13 @@ int main(int argc, char *argv[]) {
     OASIS_INT pno = atoi(argv[optind]);
     OASIS_INT total = atoi(argv[optind + 1]);
     if (pno <= 0) {
-      fprintf(stderr, "FATAL:%s: Invalid value for processno supplied\n", progname);
+      fprintf(stderr, "FATAL:%s: Invalid value for processno supplied: %s\n",
+	      progname, argv[optind]);
       parameter_error = true;
     }
     if (total <= 0) {
-      fprintf(stderr, "FATAL:%s: Invalid value for totalprocesses supplied\n", progname);
+      fprintf(stderr, "FATAL:%s: Invalid value for totalprocesses supplied: %s\n",
+	      progname, argv[optind + 1]);
       parameter_error = true;
     }
     if (parameter_error) exit(EXIT_FAILURE);


### PR DESCRIPTION
<!--start_release_notes-->
### Add Validity Checks for Process Number and Total Processes Parameters in eve
The first two command line arguments supplied to `eve` are the process number and total number of processes respectively. If no valid conversion can be performed by `atoi()`, such as when a string of letters is supplied instead of a numeric character, or 0 is supplied as a parameter, a division by zero error can occur when the modulo operator is applied in `eve.cpp:doshuffle()`. Validity checks on these two parameters have been introduced:
```
$ eve 1 10 -t
1
11
21

$ eve 0 invalid_arg -t
FATAL:eve: Invalid value for processno supplied: 0
FATAL:eve: Invalid value for totalprocesses supplied: invalid_arg
```
<!--end_release_notes-->
