### PR TITLE
Calculate mean and standard deviation by period number in aalcalc

### DIFF
--- a/src/aalcalc/aalcalc.h
+++ b/src/aalcalc/aalcalc.h
@@ -111,13 +111,10 @@ private:
 	void loadensemblemapping();
 	void process_summaryfilew(const std::string &filename);
 	void debug_process_summaryfile(const std::string &filename);
-	void do_calc_end_new();
+	void do_calc_by_period(const summarySampleslevelHeader &sh, const std::vector<sampleslevelRec> &vrec);
+	void do_calc_end(int period_no);
 	void do_sample_calc_newx(const summarySampleslevelHeader& sh, const std::vector<sampleslevelRec>& vrec);
 	void do_sample_calc_new(const summarySampleslevelHeader &sh, const std::vector<sampleslevelRec> &vrec);
-	void doaalcalc_new(const summarySampleslevelHeader& sh, const std::vector<sampleslevelRec>& vrec);
-	void applyweightings(int event_id, const std::map <int, double> &periodstoweighting, std::vector<sampleslevelRec> &vrec) ;
-	void applyweightingstomap(std::map<int, aal_rec> &m);
-	void applyweightingstomaps();
 	inline void calculatemeansddev(const aal_rec_ensemble &record,
 				       const int sample_size, const int p1,
 				       const int p2, const int periods,

--- a/src/aalcalc/aalcalc.h
+++ b/src/aalcalc/aalcalc.h
@@ -43,7 +43,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 
 #include <string>
 #include <map>
-#include <unordered_set>
 #include <vector>
 struct aal_rec_vec {
 	std::vector<float> v;
@@ -95,7 +94,6 @@ private:
 	std::vector<aal_rec> vec_analytical_aal_;
 	int max_summary_id_ = 0;
 
-	std::unordered_set<int> set_periods_;
 	int current_summary_id_ = 0;
 	std::map <int, double> periodstoweighting_;
 	std::vector<int> sidxtoensemble_;

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -148,6 +148,12 @@ struct summary_keyz {
 	int fileindex;
 };
 
+struct summary_period {
+	int summary_id;
+	int fileindex;
+	int period_no;
+};
+
 struct gulSampleslevelRec {
 	int sidx;		// This has be stored for thresholds cannot be implied
 	OASIS_FLOAT loss;		// may want to cut down to singe this causes 4 byte padding for allignment


### PR DESCRIPTION
<!--start_release_notes-->
### Calculate Mean and Standard Deviation by Period Number in aalcalc to reduce memory use
Further reductions to `aalcalc`'s memory footprint have been achieved by calculating the mean and standard deviation by period number. Therefore, the memory footprint is reduced from being in the order of the product of the number of periods and the number of samples, to depending on the number of samples only.

Therefore, assuming a float takes 4 bytes of memory, for 100,000 samples and 1,000,000 periods, previous versions of `aalcalc` would use `100,000 * 1,000,000 * 4 bytes = 400E9 bytes = 400 GB` of memory. Following this change, `aalcalc` uses `100,000 * 4 bytes = 400E3 bytes = 400 kB` of memory.
<!--end_release_notes-->
