### PR TITLE
Use summary index files from summarycalc in aalcalc

### DIFF
--- a/src/aalcalc/summaryindex.cpp
+++ b/src/aalcalc/summaryindex.cpp
@@ -117,6 +117,47 @@ namespace summaryindex {
 
 		fclose(fin);
 	}
+
+	void indexevents(const std::string &binfilename, std::string &idxfilename, std::map<summary_period, std::vector<long long>> &summaryfileperiod_to_offset, int file_id, const std::map<int, std::vector<int>> &eventtoperiods) {
+
+		FILE * fidx = fopen(idxfilename.c_str(), "r");
+		if (fidx == nullptr) {
+			fprintf(stderr, "FATAL: Cannot open %s\n", idxfilename.c_str());
+			exit(EXIT_FAILURE);
+		}
+		FILE * fbin = fopen(binfilename.c_str(), "r");
+		if (fbin == nullptr) {
+			fprintf(stderr, "FATAL: Cannot open %s\n", binfilename.c_str());
+			exit(EXIT_FAILURE);
+		}
+
+		char line[4096];
+		summary_period k;
+		k.fileindex = file_id;
+		while (fgets(line, sizeof(line), fidx) != 0) {
+			long long offset;
+			int ret = sscanf(line, "%d,%lld", &k.summary_id, &offset);
+			if (ret != 2) {
+				fprintf(stderr, "FATAL: Invalid data in file %s:\n%s", idxfilename.c_str(), line);
+				exit(EXIT_FAILURE);
+			}
+			// Get period numbers from event IDs
+			flseek(fbin, offset, SEEK_SET);
+			summarySampleslevelHeader sh;
+			size_t i = fread(&sh, sizeof(sh), 1, fbin);
+			std::map<int, std::vector<int>>::const_iterator iter = eventtoperiods.find(sh.event_id);
+			if (iter == eventtoperiods.end()) continue;   // Event not found so don't process it
+			for (auto period : iter->second) {
+				k.period_no = period;
+				summaryfileperiod_to_offset[k].push_back(offset);
+			}
+		}
+
+		fclose(fidx);
+		fclose(fbin);
+
+	}
+
 void doit(const std::string& subfolder, const std::map<int, std::vector<int>> &eventtoperiods)
 {	
 	std::string path = "work/" + subfolder;
@@ -136,7 +177,16 @@ void doit(const std::string& subfolder, const std::map<int, std::vector<int>> &e
 			if (s.length() > 4 && s.substr(s.length() - 4, 4) == ".bin") {
 				std::string s2 = path + ent->d_name;
 				files.push_back(s);
-				indexevents(s2, event_ids, summaryfileperiod_to_offset, file_index, eventtoperiods);
+				std::string s3 = s2;
+				s3.erase(s2.length() - 4);
+				s3 += ".idx";
+				FILE * fidx = fopen(s3.c_str(), "r");
+				if (fidx == nullptr) {
+					indexevents(s2, event_ids, summaryfileperiod_to_offset, file_index, eventtoperiods);
+				} else {
+					fclose(fidx);
+					indexevents(s2, s3, summaryfileperiod_to_offset, file_index, eventtoperiods);
+				}
 				file_index++;
 			}
 		}

--- a/src/aalcalc/summaryindex.cpp
+++ b/src/aalcalc/summaryindex.cpp
@@ -64,7 +64,7 @@ bool operator<(const summary_period &lhs, const summary_period &rhs) {
 
 namespace summaryindex {
 
-	void indexevents(const std::string& fullfilename, std::vector<int> &event_ids, std::map<summary_period, std::vector<long long>> &summaryfileperiod_to_offset, int file_id, const std::map<int, std::vector<int>> &eventtoperiods) {
+	void indexevents(const std::string& fullfilename, std::map<summary_period, std::vector<long long>> &summaryfileperiod_to_offset, int file_id, const std::map<int, std::vector<int>> &eventtoperiods) {
 		FILE* fin = fopen(fullfilename.c_str(), "rb");
 		if (fin == NULL) {
 			fprintf(stderr, "%s: cannot open %s\n", __func__, fullfilename.c_str());
@@ -99,10 +99,6 @@ namespace summaryindex {
 				for (auto period : eventtoperiods.at(sh.event_id)) {
 					k.period_no = period;
 					summaryfileperiod_to_offset[k].push_back(offset);
-				}
-				if (sh.event_id != last_event_id) {
-					last_event_id = sh.event_id;
-					event_ids.push_back(sh.event_id);
 				}
 				offset += sizeof(sh);
 			}
@@ -167,7 +163,6 @@ void doit(const std::string& subfolder, const std::map<int, std::vector<int>> &e
 
 	std::vector<std::string> files;
 	std::map<summary_period, std::vector<long long>> summaryfileperiod_to_offset;
-	std::vector<int> event_ids;
 	DIR* dir;
 	struct dirent* ent;
 	int file_index = 0;
@@ -182,7 +177,7 @@ void doit(const std::string& subfolder, const std::map<int, std::vector<int>> &e
 				s3 += ".idx";
 				FILE * fidx = fopen(s3.c_str(), "r");
 				if (fidx == nullptr) {
-					indexevents(s2, event_ids, summaryfileperiod_to_offset, file_index, eventtoperiods);
+					indexevents(s2, summaryfileperiod_to_offset, file_index, eventtoperiods);
 				} else {
 					fclose(fidx);
 					indexevents(s2, s3, summaryfileperiod_to_offset, file_index, eventtoperiods);


### PR DESCRIPTION
<!--start_release_notes-->
### Use summary index files from summarycalc in aalcalc
As part of the ktools `v3.6.1` release, `summarycalc` can produce index files. The index file corresponding to each `summarycalc` binary file is detected by `aalcalc`. Should the index file be found, it is used to construct the master index file. Should the index file be missing, the binary file is used to construct the master index file in the same way as before this change. As each binary file is treated as a separate entity when constructing the master index file, the absence of some or all of the corresponding index files is supported.
<!--end_release_notes-->
