### PR TITLE
Fix areaperil ID output

### DIFF
--- a/src/footprinttobin/footprinttobin.cpp
+++ b/src/footprinttobin/footprinttobin.cpp
@@ -150,7 +150,7 @@ namespace footprinttobin {
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 					fprintf(stderr, "FATAL: Error (%d): areaperil_id %llu data is not contiguous for event_id %d \n", lineno, r.areaperil_id, event_id);
 #else
-					::fprintf(stderr, "FATAL: Error (%d): areaperil_id %d data is not contiguous for event_id %d \n", lineno, r.areaperil_id, event_id);
+					::fprintf(stderr, "FATAL: Error (%d): areaperil_id %u data is not contiguous for event_id %d \n", lineno, r.areaperil_id, event_id);
 #endif
 					::exit(-1);
 				}
@@ -241,7 +241,7 @@ namespace footprinttobin {
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 					fprintf(stderr, "FATAL: Error (%d): areaperil_id %llu data is not contiguous for event_id %d \n", lineno, r.areaperil_id, event_id);
 #else
-					fprintf(stderr, "FATAL: Error (%d): areaperil_id %d data is not contiguous for event_id %d \n", lineno, r.areaperil_id, event_id);
+					fprintf(stderr, "FATAL: Error (%d): areaperil_id %u data is not contiguous for event_id %d \n", lineno, r.areaperil_id, event_id);
 #endif
 					exit(-1);
 				}

--- a/src/footprinttocsv/footprinttocsv.cpp
+++ b/src/footprinttocsv/footprinttocsv.cpp
@@ -65,7 +65,7 @@ namespace footprinttocsv {
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 			printf("%d, %llu, %d, %.10e\n", event_id, row.areaperil_id, row.intensity_bin_id, row.probability);
 #else
-			printf("%d, %d, %d, %.10e\n", event_id, row.areaperil_id, row.intensity_bin_id, row.probability);
+			printf("%d, %u, %d, %.10e\n", event_id, row.areaperil_id, row.intensity_bin_id, row.probability);
 #endif
 			i += sizeof(row);
 		}
@@ -97,7 +97,7 @@ namespace footprinttocsv {
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 			printf("%d, %llu, %d, %.10e\n", event_id, row->areaperil_id, row->intensity_bin_id, row->probability);
 #else
-			printf("%d, %d, %d, %.10e\n", event_id, row->areaperil_id, row->intensity_bin_id, row->probability);
+			printf("%d, %u, %d, %.10e\n", event_id, row->areaperil_id, row->intensity_bin_id, row->probability);
 #endif
 			row++;
 			i += sizeof(EventRow);

--- a/src/itemtobin/itemtobin.cpp
+++ b/src/itemtobin/itemtobin.cpp
@@ -61,7 +61,7 @@ namespace itemtobin {
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 			int ret = sscanf(line, "%d,%d,%llu,%d,%d", &q.id, &q.coverage_id, &q.areaperil_id, &q.vulnerability_id, &q.group_id);
 #else
-			int ret = sscanf(line, "%d,%d,%d,%d,%d", &q.id, &q.coverage_id, &q.areaperil_id, &q.vulnerability_id, &q.group_id);
+			int ret = sscanf(line, "%d,%d,%u,%d,%d", &q.id, &q.coverage_id, &q.areaperil_id, &q.vulnerability_id, &q.group_id);
 #endif 
 
 			if (ret != 5) {

--- a/src/itemtocsv/itemtocsv.cpp
+++ b/src/itemtocsv/itemtocsv.cpp
@@ -60,7 +60,7 @@ void doit(bool skipheader)
 #ifdef AREAPERIL_TYPE_UNSIGNED_LONG_LONG
 		printf("%d, %d, %llu, %d, %d\n", q.id, q.coverage_id, q.areaperil_id, q.vulnerability_id, q.group_id);
 #else
-		printf("%d, %d, %d, %d, %d\n", q.id, q.coverage_id, q.areaperil_id, q.vulnerability_id, q.group_id);
+		printf("%d, %d, %u, %d, %d\n", q.id, q.coverage_id, q.areaperil_id, q.vulnerability_id, q.group_id);
 #endif // 		
 		i = fread(&q, sizeof(q), 1, stdin);
 	}


### PR DESCRIPTION
<!--start_release_notes-->
### Fix areaperil ID output
The unsigned integer `areaperil_id` was incorrectly printed out as a signed integer in the conversion from binary to csv formats in `cdftocsv` (see issue [`ktools` issue 193](https://github.com/OasisLMF/ktools/issues/193)). This was fixed in `v3.6.0`. However, the same issue was found when converting footprint and item files. This has been fixed in the following binaries:

- `footprinttobin` (only affected error messages - the conversion process from csv to binary was and still is sound)
- `footprinttocsv`
- `itemtobin`
- `itemtocsv`

<!--end_release_notes-->