### PR TITLE
Support Hour and Minute fields in Occurrence file

### DIFF
--- a/docs/md/DataConversionComponents.md
+++ b/docs/md/DataConversionComponents.md
@@ -702,6 +702,7 @@ The occurrence file is required for certain output components which, in the refe
 
 The occurrence file also includes date fields.  
 * occ_year, occ_month, occ_day. These are all integers representing occurrence year, month and day.
+* occ_hour, occ_monute. These are optional and are all integers representing occurrence hour and minute.
 
 
 ##### File format
@@ -717,6 +718,14 @@ The csv file should contain the following fields and include a header row.
 
 The occurrence year in this example is a scenario numbered year, which cannot be expressed as a real date in a standard calendar.
 
+In addition, the following fields are optional and should comprise the sixth and seventh column respectively:
+
+| Name              | Type   |  Bytes | Description                                                         | Example     |
+|:------------------|--------|--------| :-------------------------------------------------------------------|------------:|
+| occ_hour          | int    |    4   | The hour of the event occurrence                                    |   13        |
+| occ_minute        | int    |    4   | The minute of the event occurrence                                  |   52        |
+
+The date fields are converted to a single number through an algorithm for efficient storage in the binary file. The data type for this field is either an integer when the optional date fields are not included or a long long integer when the these date fields are included. This should not be confused with the deprecated occ_date_id field.
 
 ##### occurrencetobin
 A required parameter is -P, the total number of periods of event occurrences. The total number of periods is held in the header of the binary file and used in output calculations.
@@ -724,6 +733,11 @@ A required parameter is -P, the total number of periods of event occurrences. Th
 ```
 $ occurrencetobin -P10000 < occurrence.csv > occurrence.bin
 ```
+If it is desirable to include the occ_hour and occ_minute fields in the binary file, the -H argument should be given. A flag to signify the presence of these fields is set in the header of the binary file, which is read by other kiools components. If these fields do not exist in the csv file, both are assigned the value of 0 when written to the binary file.
+```
+$ occurrencetobin -P10000 -H < occurrence.csv > occurrence.bin
+```
+
 ##### occurrencetocsv
 ```
 $ occurrencetocsv < occurrence.bin > occurrence.csv

--- a/src/aalcalc/aalcalc.cpp
+++ b/src/aalcalc/aalcalc.cpp
@@ -105,19 +105,12 @@ void aalcalc::loadperiodtoweigthing()
 
 }
 
-void aalcalc::loadoccurrence()
+template<typename T>
+void aalcalc::loadoccurrence(T &occ, FILE * fin)
 {
 
-	int date_algorithm_ = 0;
-	FILE *fin = fopen(OCCURRENCE_FILE, "rb");
-	if (fin == NULL) {
-		fprintf(stderr, "FATAL: %s: cannot open %s\n", __func__, OCCURRENCE_FILE);
-		exit(-1);
-	}
-	std::set<int>  periods;
-	size_t i = fread(&date_algorithm_, sizeof(date_algorithm_), 1, fin);	// discard date algorithm
-	i = fread(&no_of_periods_, sizeof(no_of_periods_), 1, fin);
-	occurrence occ;
+	size_t i = fread(&no_of_periods_, sizeof(no_of_periods_), 1, fin);
+	std::set<int> periods;
 	i = fread(&occ, sizeof(occ), 1, fin);
 	while (i != 0) {
 		event_count_[occ.event_id] = event_count_[occ.event_id] + 1;
@@ -132,6 +125,30 @@ void aalcalc::loadoccurrence()
 		exit(-1);
 	}
 	fclose(fin);
+
+}
+
+void aalcalc::loadoccurrence()
+{
+
+	int date_opts;
+	int granular_date = 0;
+	FILE *fin = fopen(OCCURRENCE_FILE, "rb");
+	if (fin == NULL) {
+		fprintf(stderr, "FATAL: %s: cannot open %s\n", __func__, OCCURRENCE_FILE);
+		exit(-1);
+	}
+	std::set<int> periods;
+	size_t i = fread(&date_opts, sizeof(date_opts), 1, fin);
+	granular_date = date_opts >> 1;
+	if (granular_date) {
+		occurrence_granular occ;
+		loadoccurrence(occ, fin);
+	} else {
+		occurrence occ;
+		loadoccurrence(occ, fin);
+	}
+
 }
 
 void aalcalc::indexevents(const std::string& fullfilename, std::string& filename) {

--- a/src/aalcalc/aalcalc.h
+++ b/src/aalcalc/aalcalc.h
@@ -101,6 +101,8 @@ private:
 	bool skipheader_ = false;
 	bool ord_output_ = false;
 // private functions
+	template<typename T>
+	void loadoccurrence(T &occ, FILE * fin);
 	void loadoccurrence();
 	void indexevents(const std::string& fullfilename, std::string& filename);
 	void load_event_to_summary_index(const std::string& subfolder);

--- a/src/eltcalc/eltcalc.cpp
+++ b/src/eltcalc/eltcalc.cpp
@@ -71,21 +71,12 @@ namespace eltcalc {
 		return (stype == summarycalc_id);
 	}
 
-	void GetEventRates()
+	template<typename T>
+	void GetEventRates(T &occ, FILE * fin)
 	{
-		FILE * fin = fopen(OCCURRENCE_FILE, "rb");
-		if (fin == NULL) {
-			fprintf(stderr, "FATAL: %s: Error opening file %s\n",
-				__func__, OCCURRENCE_FILE);
-			exit(EXIT_FAILURE);
-		}
-
-		int date_algorithm = 0;
-		int no_of_periods = 0;
-		occurrence occ;
 		int max_period_no = 0;
-		int i = fread(&date_algorithm, sizeof(date_algorithm), 1, fin);
-		i = fread(&no_of_periods, sizeof(no_of_periods), 1, fin);
+		int no_of_periods = 0;
+		size_t i = fread(&no_of_periods, sizeof(no_of_periods), 1, fin);
 		i = fread(&occ, sizeof(occ), 1, fin);
 		while (i != 0) {
 			event_rate_[occ.event_id] += 1 / (double)no_of_periods;
@@ -98,6 +89,27 @@ namespace eltcalc {
 		if (max_period_no > no_of_periods) {
 			fprintf(stderr, "FATAL: Maximum period number in occurrence file exceeds that in header.\n");
 			exit(EXIT_FAILURE);
+		}
+	}
+
+	void GetEventRates()
+	{
+		FILE * fin = fopen(OCCURRENCE_FILE, "rb");
+		if (fin == NULL) {
+			fprintf(stderr, "FATAL: %s: Error opening file %s\n",
+				__func__, OCCURRENCE_FILE);
+			exit(EXIT_FAILURE);
+		}
+
+		int date_opts = 0;
+		size_t i = fread(&date_opts, sizeof(date_opts), 1, fin);
+		int granular_date = date_opts >> 1;
+		if (granular_date) {
+			occurrence_granular occ;
+			GetEventRates(occ, fin);
+		} else {
+			occurrence occ;
+			GetEventRates(occ, fin);
 		}
 	}
 

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -202,6 +202,12 @@ struct occurrence {
 	int occ_date_id;		// occurrence year, month and day	
 };
 
+struct occurrence_granular {
+	int event_id;
+	int period_no;
+	long long occ_date_id;   // occurrence year, month, day, hour and minute
+};
+
 struct gulsummaryxref {
 	int coverage_id;
 	int summary_id;

--- a/src/leccalc/leccalc.cpp
+++ b/src/leccalc/leccalc.cpp
@@ -99,25 +99,42 @@ namespace leccalc {
 	}
 
 
-	void loadoccurence(std::map<int, std::vector<int> >& event_to_periods, int& totalperiods)
+	template<typename T>
+	void loadoccurrence(std::map<int, std::vector<int> >& event_to_periods,
+			    T &occ, FILE * fin)
 	{
-		FILE* fin = fopen(OCCURRENCE_FILE, "rb");
-		if (fin == NULL) {
-			fprintf(stderr, "FATAL: Error reading file %s\n", OCCURRENCE_FILE);
-			exit(-1);
-		}
-		int date_algorithm;
-		occurrence occ;
-		size_t i = fread(&date_algorithm, sizeof(date_algorithm), 1, fin);
-		i = fread(&totalperiods, sizeof(totalperiods), 1, fin);
-		i = fread(&occ, sizeof(occ), 1, fin);
+
+		size_t i = fread(&occ, sizeof(occ), 1, fin);
 		while (i != 0) {
 			event_to_periods[occ.event_id].push_back(occ.period_no);
 			i = fread(&occ, sizeof(occ), 1, fin);
 		}
+	}
+
+
+	void loadoccurrence(std::map<int, std::vector<int> >& event_to_periods,
+			    int& totalperiods)
+	{
+		FILE* fin = fopen(OCCURRENCE_FILE, "rb");
+		if (fin == NULL) {
+			fprintf(stderr, "FATAL: Error reading file %s\n",
+				OCCURRENCE_FILE);
+			exit(-1);
+		}
+
+		int date_opts = 0;
+		size_t i = fread(&date_opts, sizeof(date_opts), 1, fin);
+		i = fread(&totalperiods, sizeof(totalperiods), 1, fin);
+		int granular_date = date_opts >> 1;
+		if (granular_date) {
+			occurrence_granular occ;
+			loadoccurrence(event_to_periods, occ, fin);
+		} else {
+			occurrence occ;
+			loadoccurrence(event_to_periods, occ, fin);
+		}
 
 		fclose(fin);
-
 	}
 
 
@@ -247,7 +264,7 @@ namespace leccalc {
 		}
 		std::map<int, std::vector<int> > event_to_periods;
 		int totalperiods;
-		loadoccurence(event_to_periods, totalperiods);
+		loadoccurrence(event_to_periods, totalperiods);
 		std::vector<std::map<outkey2, OutLosses>> out_loss(2);
 
 		std::vector<std::string> files;


### PR DESCRIPTION
<!--start_release_notes-->
### Support Hour and Minute fields in Occurrence file
As part of the [Open Data Standards](https://github.com/OasisLMF/OpenDataStandards), the Moment Period Loss Table (MPLT), Quantile Period Loss Table (QPLT) and Sample Period Loss Table (SPLT) contain additional `Hour` and `Minute` time fields. To support these, the occurrence file now supports these two additional fields.

If it is desirable to include the `Hour` and `Minute` fields in the binary file, the `-H` argument should be given when creating this file:
```
occurrencetobin -P10000 -H < occurrence.csv > occurrence.bin
```
A flag to signify the presence of these fields is set in the header of the binary file. If the `Hour` and `Minute` fields do not exist in the csv file and the `-H` argument is given, both fields are assigned the value of 0. To allow for backwards compatibility, all components that read the occurrence file use the flags in its header to determine whether the `Hour` and `Minute` fields are present.
<!--end_release_notes-->
