### PR TITLE
MacOS build issue fix

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -78,9 +78,9 @@
 ######################################################################
 
 if [ -d ".git" ]; then
-	(cat VERSION.in  && git log -1 --pretty=format:%cdt) |  tr '\n' 'A' | sed 's/A/ - git update: /' > VERSION
+	(cat VERSION.in  && git log -1 --pretty=format:%cdt) |  tr '\n' 'A' | sed 's/A/ - git update: /' > VERSION.txt
 else
-    cat VERSION.in  > VERSION
+    cat VERSION.in  > VERSION.txt
 fi
 
 uname -a

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([ktools],  m4_esyscmd([tr -d '\n' < VERSION]), [support@oasislmf.org])
+AC_INIT([ktools],  m4_esyscmd([tr -d '\n' < VERSION.txt]), [support@oasislmf.org])
 #AM_INIT_AUTOMAKE([gnu])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
<!--start_release_notes-->
### MacOS build issue fix
Prevent `VERSION` file being read as source when building ktools on MacOS big-sur
 
<!--end_release_notes-->
