### PR TITLE
Feature/927 step calcrules

### DIFF
--- a/docs/md/fmprofiles.md
+++ b/docs/md/fmprofiles.md
@@ -43,6 +43,8 @@ This section specifies the attributes and rules for the following list of Financ
 |deductible with attachment and share                                |   34       |
 |deductible % loss with min and/or max deductible and limit % loss   |   35       |
 |deductible with min and/or max deductible and limit % loss          |   36       |
+|% tiv trigger and % loss step payout with limit                     |   37       |
+|conditional coverage payouts based on prior step payouts            |   38       |
 
 |calcrule_id |d1|d2|d3|a1|l1|sh1|sh2|sh3|st|ts|te|ps|pe|l2|sc1|sc2|  
 |:-----------|--|--|--|--|--|---|---|---|--|--|--|--|--|--|---|--:|
@@ -83,6 +85,8 @@ This section specifies the attributes and rules for the following list of Financ
 |   34       |x |  |  |x |  |x  |   |   |  |  |  |  |  |  |   |   |
 |   35       |x |x |x |  |x |   |   |   |  |  |  |  |  |  |   |   |
 |   36       |x |x |x |  |x |   |   |   |  |  |  |  |  |  |   |   |
+|   37       |x |  |  |  |x |   |   |   |x |x |x |x |  |x |x  |x  |
+|   38       |  |  |  |  |  |   |   |   |x |x |x |  |  |x |x  |x  |
 
 The fields with an x are those which are required by the profile. The full names of the fields are as follows;
 
@@ -136,7 +140,7 @@ Loss adjustments due to minimum and maximum deductibles may lead to breaching or
 We introduce the following variables;
 
 * **over limit** is the sum of the amount by which limits are exceeded at the prior level calculation (positive measure)
-* **under limit** is the sum of the amount by which losses fall short of limits at the prior level calculation (positive measure)
+* **under limit** is the smaller of the effective deductible and sum of the amount by which losses fall short of limits at the prior level calculation (positive measure). It represents the amount by which the loss can be adjusted upwards due to the enforcement of a maximum deductible at the current level.
 * **loss delta** is the amount by which the loss would change due to the enforcement of a minimum or maximum ignoring prior level limits (positive for loss increase and negative for loss decrease). The loss is adjusted by an amount up to the loss delta depending on the values carried in the under and over limit variables
 
 ### Scenarios for under and over limit

--- a/src/fmcalc/fmcalcrules.cpp
+++ b/src/fmcalc/fmcalcrules.cpp
@@ -581,6 +581,126 @@ void applycalcrule_stepped(const profile_rec_new& profile, LossRec& x, int layer
 			x.loss = loss;
 		}
 		break;
+		case 37:
+		{
+			OASIS_FLOAT deductible1 = 0;
+			OASIS_FLOAT tstart = 0;
+			OASIS_FLOAT tend = 0;
+			OASIS_FLOAT payout = 0;
+			OASIS_FLOAT scale1 = 0;
+			OASIS_FLOAT scale2 = 0;
+			OASIS_FLOAT limit1 = 0;
+			OASIS_FLOAT limit2 = 0;
+
+
+			for (auto y : profile.tc_vec) {
+				if (y.tc_id == deductible_1) deductible1 = y.tc_val;
+				if (y.tc_id == trigger_start) tstart = y.tc_val;
+				if (y.tc_id == trigger_end) tend = y.tc_val;
+				if (y.tc_id == payout_start) payout = y.tc_val;
+				if (y.tc_id == scale_1) scale1 = y.tc_val;
+				if (y.tc_id == scale_2) scale2 = y.tc_val;
+				if (y.tc_id == limit_1) limit1 = y.tc_val;
+				if (y.tc_id == limit_2) limit2 = y.tc_val;
+			}
+			// Step policy: single (final) step with % loss payout and limit, extra expense payout with limit amount, and a gross up factor for debris removal
+			OASIS_FLOAT loss = 0;
+			OASIS_FLOAT condloss = 0;
+			loss = x.loss / x.accumulated_tiv;
+			if (tend == 1) { // if the upper threshold is 100% then include loss = tend in the conditional calculation
+				if (loss >= tstart) {
+					loss = (payout * x.loss) - deductible1; //calculate primary payout
+					if (loss < 0) loss = 0;
+					if (loss > limit1) loss = limit1;
+					condloss = loss * scale2; //calculate conditional payout based on primary coverage payout (extra expenses)
+					if (condloss > limit2) condloss = limit2; //limit conditional payout
+					loss = loss + condloss; // main coverage + extra expense payout
+					loss = loss * (1 + scale1); // gross up for debris removal
+				}
+				else loss = 0;
+			}
+			else { // if the upper threshold is not 100% then do not include loss = tend in the conditional calculation
+				if (loss < tend) {
+					if (loss >= tstart) {
+						loss = (payout * x.loss) - deductible1; //calculate primary payout
+						if (loss < 0) loss = 0;
+						if (loss > limit1) loss = limit1;
+						condloss = loss * scale2; //calculate conditional payout (extra expenses)
+						if (condloss > limit2) condloss = limit2; //limit conditional payout
+						loss = loss + condloss; // main coverage + extra expense payout
+						loss = loss * (1 + scale1); // gross up for debris removal
+					}
+					else loss = 0;
+				}
+				else loss = 0;
+			}
+
+			if (profile.step_id == 1) {
+				x.step_loss = loss;
+			}
+			else {
+				x.step_loss = x.step_loss + loss;
+			}
+			if (isLast == true) {
+				x.loss = x.step_loss;
+			}
+		}
+		break;
+		case 38:
+		{
+			OASIS_FLOAT tstart = 0;
+			OASIS_FLOAT tend = 0;
+			OASIS_FLOAT scale1 = 0;
+			OASIS_FLOAT scale2 = 0;
+			OASIS_FLOAT limit2 = 0;
+
+
+			for (auto y : profile.tc_vec) {
+				if (y.tc_id == trigger_start) tstart = y.tc_val;
+				if (y.tc_id == trigger_end) tend = y.tc_val;
+				if (y.tc_id == scale_1) scale1 = y.tc_val;
+				if (y.tc_id == scale_2) scale2 = y.tc_val;
+				if (y.tc_id == limit_2) limit2 = y.tc_val;
+			}
+			// Step policy: conditional payouts only, triggered by loss % TIV.  Extra expense payout with limit amount, and a gross up factor for debris removal, with payout based on prior step payout
+			OASIS_FLOAT loss = 0;
+			OASIS_FLOAT trigger = 0;
+			OASIS_FLOAT condloss = 0;
+			OASIS_FLOAT debrisloss = 0;
+			trigger = x.loss / x.accumulated_tiv;
+			if (tend == 1) { // if the upper threshold is 100% then include loss = tend in the conditional calculation
+				if (trigger >= tstart) {
+					condloss = x.step_loss * scale2; //calculate conditional payout based on prior step payout (extra expenses)
+					if (condloss > limit2) condloss = limit2; //limit conditional payout
+					debrisloss = (x.step_loss + condloss) * scale1; // debris removal uplift
+					loss = condloss + debrisloss; // payout is conditional loss for extra expenses plus full debris removal uplift
+				}
+				else loss = 0;
+			}
+			else { // if the upper threshold is not 100% then do not include loss = tend in the conditional calculation
+				if (trigger < tend) {
+					if (trigger >= tstart) {
+						condloss = x.step_loss * scale2; //calculate conditional payout based on prior step payout (extra expenses)
+						if (condloss > limit2) condloss = limit2; //limit conditional payout
+						debrisloss = (x.step_loss + condloss) * scale1; // debris removal uplift
+						loss = condloss + debrisloss; // payout is conditional loss for extra expenses plus full debris removal uplift
+					}
+					else loss = 0;
+				}
+				else loss = 0;
+			}
+
+			if (profile.step_id == 1) {
+				x.step_loss = loss;
+			}
+			else {
+				x.step_loss = x.step_loss + loss;
+			}
+			if (isLast == true) {
+				x.loss = x.step_loss;
+			}
+		}
+		break;
 		case 100:	// noop
 		{
 			x.loss = x.loss;
@@ -1534,6 +1654,22 @@ void fmcalc::init_profile__stepped_rec(fm_profile_step& f)
 			add_tc(deductible_1, f.deductible1, p.tc_vec);
 			add_tc(share_1, f.share1, p.tc_vec);
 			add_tc(attachment_1, f.attachment, p.tc_vec);
+			break;
+		case 37:
+			add_tc(deductible_1, f.deductible1, p.tc_vec);
+			add_tc(limit_2, f.limit2, p.tc_vec);
+			add_tc(limit_1, f.limit1, p.tc_vec);
+			add_tc(payout_start, f.payout_start, p.tc_vec);
+			add_tc(scale_1, f.scale1, p.tc_vec);
+			add_tc(scale_2, f.scale2, p.tc_vec);
+			add_tc(trigger_start, f.trigger_start, p.tc_vec);
+			add_tc(trigger_end, f.trigger_end, p.tc_vec);
+		case 38:
+			add_tc(limit_2, f.limit2, p.tc_vec);
+			add_tc(scale_1, f.scale1, p.tc_vec);
+			add_tc(scale_2, f.scale2, p.tc_vec);
+			add_tc(trigger_start, f.trigger_start, p.tc_vec);
+			add_tc(trigger_end, f.trigger_end, p.tc_vec);
 			break;
 		case 100:
 			break;

--- a/src/fmcalc/fmcalcrules.cpp
+++ b/src/fmcalc/fmcalcrules.cpp
@@ -289,10 +289,7 @@ void applycalcrule_stepped(const profile_rec_new& profile, LossRec& x, int layer
 				if (loss >= tstart) {
 					loss = (payout * x.loss) - deductible1; //calculate primary payout
 					if (loss < 0) loss = 0;
-					if (payout == 0) {
-						condloss = x.step_loss * scale2; //special case to calculate only the conditional coverage loss (extra expenses) based on full input loss where there is no primary payout
-					}
-					else condloss = loss * scale2; //calculate conditional payout based on primary coverage payout (extra expenses)
+					condloss = loss * scale2; //calculate conditional payout based on primary coverage payout (extra expenses)
 					if (condloss > limit2) condloss = limit2; //limit conditional payout
 					loss = loss + condloss; // main coverage + extra expense payout
 					loss = loss * (1 + scale1); // gross up for debris removal
@@ -304,10 +301,7 @@ void applycalcrule_stepped(const profile_rec_new& profile, LossRec& x, int layer
 					if (loss >= tstart) {
 						loss = (payout * x.loss) - deductible1; //calculate primary payout
 						if (loss < 0) loss = 0;
-						if (payout == 0) {
-							condloss = x.step_loss * scale2; //special case to calculate only the conditional coverage loss (extra expenses) based on the step loss brought forward.
-						}
-						else condloss = loss * scale2; //calculate conditional payout (extra expenses)
+						condloss = loss * scale2; //calculate conditional payout (extra expenses)
 						if (condloss > limit2) condloss = limit2; //limit conditional payout
 						loss = loss + condloss; // main coverage + extra expense payout
 						loss = loss * (1 + scale1); // gross up for debris removal


### PR DESCRIPTION
https://github.com/OasisLMF/OasisLMF/issues/927
https://github.com/OasisLMF/OasisLMF/issues/830
<!--start_release_notes-->
### Step policy calcrule enhancements in fmcalc
Removed special logic in calcrule 28 when PayoutStart = 0 
Introduced new step policy calcrules 37 (28 with a limit) and 38 (conditional coverages payout only)
<!--end_release_notes-->
