### PR TITLE
Remove SourceExposure field from ORD output

### DIFF
--- a/src/aalcalc/aalcalc.cpp
+++ b/src/aalcalc/aalcalc.cpp
@@ -464,10 +464,14 @@ void aalcalc::outputresultscsv_new(std::vector<aal_rec>& vec_aal, int periods,in
 			const int bufferSize = 4096;
 			char buffer[bufferSize];
 			int strLen;
-			strLen = snprintf(buffer, bufferSize, "%d,%d,%f,%f,%f",
+			strLen = snprintf(buffer, bufferSize, "%d,%d,%f,%f",
 					  v_iter->summary_id, v_iter->type,
-					  mean, sd_dev,
-					  v_iter->max_exposure_value);
+					  mean, sd_dev);
+			if (ord_output_ == false) {
+				strLen += snprintf(buffer+strLen,
+						   bufferSize-strLen, "%f",
+						   v_iter->max_exposure_value);
+			}
 			// If relevant use ensemble ID = 0 for calculations
 			// across all ensembles
 			if (sidxtoensemble_.size() > 0)
@@ -482,7 +486,7 @@ void aalcalc::outputresultscsv_new()
 {
 	if (skipheader_ == false) {
 		if (ord_output_ == true) {
-			printf("SummaryID,SampleType,MeanLoss,SDLoss,SourceExposure");
+			printf("SummaryID,SampleType,MeanLoss,SDLoss");
 		} else {
 			printf("summary_id,type,mean,standard_deviation,exposure_value");
 			if (sidxtoensemble_.size() > 0) printf(",ensemble_id");

--- a/src/aalcalc/aalcalc.cpp
+++ b/src/aalcalc/aalcalc.cpp
@@ -469,7 +469,7 @@ void aalcalc::outputresultscsv_new(std::vector<aal_rec>& vec_aal, int periods,in
 					  mean, sd_dev);
 			if (ord_output_ == false) {
 				strLen += snprintf(buffer+strLen,
-						   bufferSize-strLen, "%f",
+						   bufferSize-strLen, ",%f",
 						   v_iter->max_exposure_value);
 			}
 			// If relevant use ensemble ID = 0 for calculations


### PR DESCRIPTION
<!--start_release_notes-->
### Remove SourceExposure field from Period Average Loss Table
The `SourceExposure` field has been removed from the Period Average Loss Table (PALT) written by `aalcalc`. The field was incorrectly calculated as the maximum exposure value across all samples for each summary ID.

The `SourceExposure` field is the sum of the Total Insured Value (TIV) from input exposures, which is currently calculated in the exposure summary report. Currently, this report is not part of the ktools kernel.
<!--end_release_notes-->