### PR TITLE
Remove command line flag for execution mode from gulcalc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ depcomp
 install-sh
 missing
 VERSION
+VERSION.txt
 build
 examples2
 .gdbinit*

--- a/src/gulcalc/doit.cpp
+++ b/src/gulcalc/doit.cpp
@@ -171,19 +171,21 @@ void doit(const gulcalcopts &opt)
 	itemout = opt.itemout;
 	covout = opt.covout;
 	corrout = opt.corrout;
+
+	void (gulcalc::*mode)();
+	mode = &gulcalc::mode0;   // Classic gulcalc
 	if (opt.itemLevelOutput == true) {
-		if (opt.allocRule == 0 || opt.allocRule == 1 || opt.allocRule == 2) lossWriter = itemWriter;   // If alloc rule has been specified
-		else if (opt.mode == 0) itmWriter = itemWriter;
-		else {
-			fprintf(stderr, "FATAL: gulcalc: Invalid combination of alloc rule %d and mode %d\n", opt.allocRule, opt.mode);
-			exit(-1);
+		if (opt.allocRule > -1) {
+			lossWriter = itemWriter;   // Loss stream
+			if (opt.allocRule > 0) mode = &gulcalc::mode1;   // Back allocation
+		} else {
+			itmWriter = itemWriter;   // Item stream
 		}
 	}
 	if (opt.coverageLevelOutput == true) covWriter = coverageWriter;
     	if(opt.correlatedLevelOutput == true) corrWriter = correlatedWriter;
-	gulcalc g(damagebindictionary_vec, coverages, item_map, rnd, rnd0,   itmWriter, covWriter,lossWriter, corrWriter, iGetrec,opt);
-	if (opt.mode == 0) g.mode0();		// classic gulcalc
-	if (opt.mode == 1) g.mode1();		// first type of back allocation
+	gulcalc g(damagebindictionary_vec, coverages, item_map, rnd, rnd0, itmWriter, covWriter, lossWriter, corrWriter, iGetrec, opt);
+	(g.*mode)();   // g.mode0() or g.mode1()
 
 	return;
 

--- a/src/gulcalc/gulcalc.h
+++ b/src/gulcalc/gulcalc.h
@@ -110,7 +110,6 @@ struct gulcalcopts {
 	FILE *itemout = stdout;
 	FILE *covout = stdout;
 	FILE *corrout = stdout;
-	int mode = 0;		// default mode = 0
 	int allocRule = -1;   // default is unset
 	bool benchmark = false;
 };
@@ -214,7 +213,7 @@ public:
 			damagebindictionary_vec_ = &damagebindictionary_vec;
 			coverages_ = &tivs;
 			cov_.resize(coverages_->size());
-			if (opt.mode == 1) {
+			if (opt.allocRule > 0) {
 				mode1_.resize(coverages_->size());
 				mode1_stats_.resize(coverages_->size());
 			}


### PR DESCRIPTION
<!--start_release_notes-->
### Remove command line flag for execution mode from gulcalc
The command line flag `-m` for setting the execution mode in `gulcalc` has been removed to simplify user input. The effects of the mode flag can be replicated by using the alloc rule flag `-a`. For example, `-m1` (back allocation) can be replicated using alloc rules 1 or 2:
```
$ eve 1 1 | getmodel | gulcalc -S10 -L0 -a1 -i gulcalc_out.bin
$ eve 1 1 | getmodel | gulcalc -S10 -L0 -a2 -i gulcalc_out.bin
```
Classic `gulcalc` output can be achieved by setting an alloc rule of 0 (loss stream) or not setting one at all (deprecated item or coverage stream):
```
$ eve 1 1 | getmodel | gulcalc -S10 -L0 -a0 -i gulcalc_out.bin
$ eve 1 1 | getmodel | gulcalc -S10 -L0 -i gulcalc_out.bin
$ eve 1 1 | getmodel | gulcalc -S10 -L0 -c gulcalc_out.bin
```
The deprecated coverage stream output is incompatible with alloc rules 1 and 2, and is ignored:
```
$ eve 1 1 | getmodel | gulcalc -S10 -L0 -a1 -i gulcalc_out_item.bin -c gulcalc_out_coverage.bin
WARNING: Alloc rule 1 and coverage output are incompatible - ignoring coverage output
```
<!--end_release_notes-->