### PR TITLE
Fix quantile losses in Quantile Period Loss Tables (QPLT)

### DIFF
--- a/src/pltcalc/pltcalc.cpp
+++ b/src/pltcalc/pltcalc.cpp
@@ -507,9 +507,7 @@ namespace pltcalc {
 					chance_of_loss = sr.loss;
 				} else if (sr.sidx == max_loss_idx) {
 					max_loss = sr.loss;
-				}
-
-				if (sr.sidx == -1) {
+				} else if (sr.sidx == mean_idx) {
 					domeanout(sh, sr.loss, OutputData,
 						  outFile, m_occ, vp,
 						  chance_of_loss, max_loss);


### PR DESCRIPTION
<!--start_release_notes-->
### Fix quantile losses in Quantile Period Loss Table (QPLT)
Quantile losses for the same `event_id` and `summary_id` differed between the Quantile Event Loss Table (QELT) and Quantile Period Loss Table (QPLT). This was because the `ChanceOfLoss` and `MaxLoss` values from the output of `summarycalc` were erroneously included in the calculation of these losses.

The contributions from `ChanceOfLoss` and `MaxLoss` have been removed. The quantile losses between the QELT and QPLT now agree for the same `event_id` and `summary_id`.
<!--end_release_notes-->
