### PR TITLE
Ignore chance of loss and maximum loss values when filling losses vec…

### DIFF
--- a/src/pltcalc/pltcalc.cpp
+++ b/src/pltcalc/pltcalc.cpp
@@ -507,9 +507,7 @@ namespace pltcalc {
 					chance_of_loss = sr.loss;
 				} else if (sr.sidx == max_loss_idx) {
 					max_loss = sr.loss;
-				}
-
-				if (sr.sidx == -1) {
+				} else if (sr.sidx == mean_idx) {
 					domeanout(sh, sr.loss, OutputData,
 						  outFile, m_occ, vp,
 						  chance_of_loss, max_loss);


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->
#272 
<!--start_release_notes-->
### Bug fix for quantile losses in pltcalc
Chance of loss and max loss samples excluded from loss quantile calculation which should only be using sidx >= 1.
<!--end_release_notes-->
