### PR TITLE
Ignore events that do not exist in occurrence file when creating summary indexes in aalcalc

### DIFF
--- a/src/aalcalc/summaryindex.cpp
+++ b/src/aalcalc/summaryindex.cpp
@@ -96,9 +96,12 @@ namespace summaryindex {
 				summary_period k;
 				k.summary_id = sh.summary_id;
 				k.fileindex = file_id;
-				for (auto period : eventtoperiods.at(sh.event_id)) {
-					k.period_no = period;
-					summaryfileperiod_to_offset[k].push_back(offset);
+				auto iter = eventtoperiods.find(sh.event_id);
+				if (iter != eventtoperiods.end()) {
+					for (auto period : iter->second) {
+						k.period_no = period;
+						summaryfileperiod_to_offset[k].push_back(offset);
+					}
 				}
 				offset += sizeof(sh);
 			}

--- a/src/aalcalc/summaryindex.cpp
+++ b/src/aalcalc/summaryindex.cpp
@@ -93,11 +93,11 @@ namespace summaryindex {
 		while (i != 0) {
 			i = fread(&sh, sizeof(sh), 1, fin);
 			if (i != 0) {
-				summary_period k;
-				k.summary_id = sh.summary_id;
-				k.fileindex = file_id;
 				auto iter = eventtoperiods.find(sh.event_id);
 				if (iter != eventtoperiods.end()) {
+					summary_period k;
+					k.summary_id = sh.summary_id;
+					k.fileindex = file_id;
 					for (auto period : iter->second) {
 						k.period_no = period;
 						summaryfileperiod_to_offset[k].push_back(offset);


### PR DESCRIPTION
<!--start_release_notes-->
### Ignore events that do not exist in occurrence file when creating summary indexes in aalcalc
It is no longer a requirement for all event IDs to be present in the occurrence file in order to create the summary index files in `aalcalc`. Should an event ID be encountered that does not exist in the occurrence file, only its offset is recorded.
<!--end_release_notes-->
