### PR TITLE
Suppress FATAL error messages during build process if parquet libraries have not been linked to binaries

### DIFF
--- a/ktest/runtests.sh
+++ b/ktest/runtests.sh
@@ -65,7 +65,7 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
   		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -77,7 +77,7 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin  
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
 	fi
@@ -85,7 +85,7 @@ installertest()
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -171,7 +171,7 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
-	 if [ PARQUET_OUTPUT -eq 1 ]; then
+	 if [ ${PARQUET_OUTPUT} -eq 1 ]; then
  		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
 	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
 	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
@@ -200,7 +200,7 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
@@ -262,12 +262,12 @@ installertest()
      # checksums		
 	if [ "$SYSTEMNAME" == "Darwin" ]; then
 	 	shasum -c ../$CTRL.sha1
-		if [ PARQUET_OUTPUT -eq 1 ]; then
+		if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 			shasum -c ../$CTRL_PARQUET.sha1
 		fi
 	else
 	 	sha1sum -c ../$CTRL.sha1
-		if [ PARQUET_OUTPUT -eq 1 ]; then
+		if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 			sha1sum -c ../$CTRL_PARQUET.sha1
 		fi
 	fi

--- a/ktest/runtests.sh
+++ b/ktest/runtests.sh
@@ -37,7 +37,7 @@ installertest()
 	cd examples
 
 	# establish whether binaries have been linked to parquet libraries
-	if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+	if ../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
 		PARQUET_OUTPUT=1
 	fi
 
@@ -64,7 +64,7 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
   		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -76,7 +76,7 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin  
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
 	fi
@@ -84,7 +84,7 @@ installertest()
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -170,7 +170,7 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
-	 if [[ -z ${PARQUET_OUTPUT} ]]; then
+	 if [[ -v PARQUET_OUTPUT ]]; then
  		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
 	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
 	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
@@ -199,7 +199,7 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	if [[-z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
@@ -261,12 +261,12 @@ installertest()
      # checksums		
 	if [ "$SYSTEMNAME" == "Darwin" ]; then
 	 	shasum -c ../$CTRL.sha1
-		if [[ -z ${PARQUET_OUTPUT} ]]; then
+		if [[ -v PARQUET_OUTPUT ]]; then
 			shasum -c ../$CTRL_PARQUET.sha1
 		fi
 	else
 	 	sha1sum -c ../$CTRL.sha1
-		if [[ -z ${PARQUET_OUTPUT} ]]; then
+		if [[ -v PARQUET_OUTPUT ]]; then
 			sha1sum -c ../$CTRL_PARQUET.sha1
 		fi
 	fi

--- a/ktest/runtests.sh
+++ b/ktest/runtests.sh
@@ -36,6 +36,11 @@ installertest()
 
 	cd examples
 
+	# establish whether binaries have been linked to parquet libraries
+	if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+		PARQUET_OUTPUT=1
+	fi
+
 	# test eve
 	../src/eve/eve -n 1 2 > ../ktest/testout/eveout1.bin
 	../src/eve/eve -n 2 2 > ../ktest/testout/eveout2.bin
@@ -59,8 +64,10 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-  	../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
-	../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+  		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
+		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	fi
 
 	# test eltcalc
 	../src/eltcalc/eltcalc < ../ktest/testout/gulsummarycalc1.bin > ../ktest/testout/gulelt1.csv
@@ -69,14 +76,18 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin  
-	../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
-	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt1.csv -Q ../ktest/testout/gulqelt1.csv < ../ktest/testout/gulsummarycalc1.bin  
-	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin 
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin  
+		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
+	fi
+	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt1.csv -Q ../ktest/testout/gulqelt1.csv < ../ktest/testout/gulsummarycalc1.bin
+	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin 
-	../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
+		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	fi
 	../src/pltcalc/pltcalc -M ../ktest/testout/gulmplt1.csv -Q ../ktest/testout/gulqplt1.csv -S ../ktest/testout/gulsplt1.csv < ../ktest/testout/gulsummarycalc1.bin 
 	../src/pltcalc/pltcalc -M ../ktest/testout/gulmplt2.csv -Q ../ktest/testout/gulqplt2.csv -S ../ktest/testout/gulsplt2.csv < ../ktest/testout/gulsummarycalc2.bin 
 
@@ -159,14 +170,16 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
- 	../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
-	 ../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
-	 ../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
-	 ../src/ordleccalc/ordleccalc  -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2.parquet -p ../ktest/testout/fm_psept_2.parquet
- 	 ../src/ordleccalc/ordleccalc -r -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1_r.parquet -p ../ktest/testout/gul_psept_1_r.parquet
-	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2_r.parquet -p ../ktest/testout/gul_psept_2_r.parquet
-	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1_r.parquet -p ../ktest/testout/fm_psept_1_r.parquet
-	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2_r.parquet -p ../ktest/testout/fm_psept_2_r.parquet
+	 if [[ -z ${PARQUET_OUTPUT} ]]; then
+ 		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
+	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
+	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
+	 	../src/ordleccalc/ordleccalc  -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2.parquet -p ../ktest/testout/fm_psept_2.parquet
+ 	 	../src/ordleccalc/ordleccalc -r -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1_r.parquet -p ../ktest/testout/gul_psept_1_r.parquet
+	 	../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2_r.parquet -p ../ktest/testout/gul_psept_2_r.parquet
+	 	../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1_r.parquet -p ../ktest/testout/fm_psept_1_r.parquet
+	 	../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2_r.parquet -p ../ktest/testout/fm_psept_2_r.parquet
+	 fi
 	
 
 	# test pltcalc
@@ -186,10 +199,12 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
-	../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
-	../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
-	../src/aalcalc/aalcalc -p ../ktest/testout/fmalt2.parquet -Kfm2/summary
+	if [[-z ${PARQUET_OUTPUT} ]]; then
+		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
+		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
+		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
+		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt2.parquet -Kfm2/summary
+	fi
 
 	# test stream conversion components
 	# stdout to csv
@@ -246,12 +261,12 @@ installertest()
      # checksums		
 	if [ "$SYSTEMNAME" == "Darwin" ]; then
 	 	shasum -c ../$CTRL.sha1
-		if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+		if [[ -z ${PARQUET_OUTPUT} ]]; then
 			shasum -c ../$CTRL_PARQUET.sha1
 		fi
 	else
 	 	sha1sum -c ../$CTRL.sha1
-		if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+		if [[ -z ${PARQUET_OUTPUT} ]]; then
 			sha1sum -c ../$CTRL_PARQUET.sha1
 		fi
 	fi

--- a/ktest/runtests.sh
+++ b/ktest/runtests.sh
@@ -37,6 +37,7 @@ installertest()
 	cd examples
 
 	# establish whether binaries have been linked to parquet libraries
+	PARQUET_OUTPUT=0
 	if ../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
 		PARQUET_OUTPUT=1
 	fi
@@ -64,7 +65,7 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
   		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -76,7 +77,7 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin  
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
 	fi
@@ -84,7 +85,7 @@ installertest()
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -170,7 +171,7 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
-	 if [[ -v PARQUET_OUTPUT ]]; then
+	 if [ PARQUET_OUTPUT -eq 1 ]; then
  		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
 	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
 	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
@@ -199,7 +200,7 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
@@ -261,12 +262,12 @@ installertest()
      # checksums		
 	if [ "$SYSTEMNAME" == "Darwin" ]; then
 	 	shasum -c ../$CTRL.sha1
-		if [[ -v PARQUET_OUTPUT ]]; then
+		if [ PARQUET_OUTPUT -eq 1 ]; then
 			shasum -c ../$CTRL_PARQUET.sha1
 		fi
 	else
 	 	sha1sum -c ../$CTRL.sha1
-		if [[ -v PARQUET_OUTPUT ]]; then
+		if [ PARQUET_OUTPUT -eq 1 ]; then
 			sha1sum -c ../$CTRL_PARQUET.sha1
 		fi
 	fi

--- a/ktest/runtestsx.sh
+++ b/ktest/runtestsx.sh
@@ -36,6 +36,11 @@ installertest()
 	CTRL_PARQUET=ctrl_parquet
 	cd examples
 
+	# establish whether binaries have been linked to parquet libraries
+	if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+		PARQUET_OUTPUT=1
+	fi
+
 	# test eve
 	../src/eve/eve -n 1 2 > ../ktest/testout/eveout1.bin
 	../src/eve/eve -n 2 2 > ../ktest/testout/eveout2.bin
@@ -59,8 +64,10 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-  	../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
-	../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+  		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
+		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	fi
 
 	# test eltcalc
 	../src/eltcalc/eltcalc < ../ktest/testout/gulsummarycalc1.bin > ../ktest/testout/gulelt1.csv
@@ -69,16 +76,20 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin  
-	../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
-	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt1.csv -Q ../ktest/testout/gulqelt1.csv < ../ktest/testout/gulsummarycalc1.bin  
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin
+		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	fi
+	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt1.csv -Q ../ktest/testout/gulqelt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin 
-	../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin 
-	../src/pltcalc/pltcalc -M ../ktest/testout/gulmplt1.csv -Q ../ktest/testout/gulqplt1.csv -S ../ktest/testout/gulsplt1.csv < ../ktest/testout/gulsummarycalc1.bin 
-	../src/pltcalc/pltcalc -M ../ktest/testout/gulmplt2.csv -Q ../ktest/testout/gulqplt2.csv -S ../ktest/testout/gulsplt2.csv < ../ktest/testout/gulsummarycalc2.bin 
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
+		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
+	fi
+	../src/pltcalc/pltcalc -M ../ktest/testout/gulmplt1.csv -Q ../ktest/testout/gulqplt1.csv -S ../ktest/testout/gulsplt1.csv < ../ktest/testout/gulsummarycalc1.bin
+	../src/pltcalc/pltcalc -M ../ktest/testout/gulmplt2.csv -Q ../ktest/testout/gulqplt2.csv -S ../ktest/testout/gulsplt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test leccalc
 	cp ../ktest/testout/gulsummarycalc2.bin work/gul2/summary/gulsummarycalc2.bin
@@ -114,14 +125,16 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
- 	../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
-	 ../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
-	 ../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
-	 ../src/ordleccalc/ordleccalc  -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2.parquet -p ../ktest/testout/fm_psept_2.parquet
- 	 ../src/ordleccalc/ordleccalc -r -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1_r.parquet -p ../ktest/testout/gul_psept_1_r.parquet
-	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2_r.parquet -p ../ktest/testout/gul_psept_2_r.parquet
-	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1_r.parquet -p ../ktest/testout/fm_psept_1_r.parquet
-	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2_r.parquet -p ../ktest/testout/fm_psept_2_r.parquet
+	 if [[ -z ${PARQUET_OUTPUT} ]]; then
+ 		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
+	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
+	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
+	 	../src/ordleccalc/ordleccalc  -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2.parquet -p ../ktest/testout/fm_psept_2.parquet
+ 	 	../src/ordleccalc/ordleccalc -r -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1_r.parquet -p ../ktest/testout/gul_psept_1_r.parquet
+	 	../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2_r.parquet -p ../ktest/testout/gul_psept_2_r.parquet
+	 	../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1_r.parquet -p ../ktest/testout/fm_psept_1_r.parquet
+	 	../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_2_r.parquet -p ../ktest/testout/fm_psept_2_r.parquet
+	 fi
 
 	# test pltcalc
 	../src/pltcalc/pltcalc < ../ktest/testout/gulsummarycalc1.bin > ../ktest/testout/gulplt1.csv
@@ -146,10 +159,12 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
-	../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
-	../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
-	../src/aalcalc/aalcalc -p ../ktest/testout/fmalt2.parquet -Kfm2/summaryv
+	if [[ -z ${PARQUET_OUTPUT} ]]; then
+		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
+		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
+		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
+		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt2.parquet -Kfm2/summary
+	fi
 	
 	# test stream conversion components
 	# stdout to csv
@@ -183,9 +198,9 @@ installertest()
 	../src/fmxreftocsv/fmxreftocsv < ../examples/input/fm_xref.bin | ../src/fmxreftobin/fmxreftobin > ../ktest/testout/fm_xref.bin
 
 	../src/gulsummaryxreftocsv/gulsummaryxreftocsv < ../examples/input/gulsummaryxref.bin | ../src/gulsummaryxreftobin/gulsummaryxreftobin > ../ktest/testout/gulsummaryxref.bin
-	
+
 	../src/fmsummaryxreftocsv/fmsummaryxreftocsv < ../examples/input/fmsummaryxref.bin | ../src/fmsummaryxreftobin/fmsummaryxreftobin > ../ktest/testout/fmsummaryxref.bin
-    
+
     ../src/returnperiodtocsv/returnperiodtocsv < ../examples/input/returnperiods.bin | ../src/returnperiodtobin/returnperiodtobin > ../ktest/testout/returnperiods.bin
 
 	../src/occurrencetocsv/occurrencetocsv < ../examples/input/occurrence.bin | ../src/occurrencetobin/occurrencetobin -P10000 > ../ktest/testout/occurrence.bin
@@ -205,7 +220,7 @@ installertest()
 
      # checksums		
 	 sha1sum -c ../$CTRL.sha1
-	 if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+	 if [[ -z ${PARQUET_OUTPUT} ]]; then
 		 sha1sum -c ../$CTRL_PARQUET.sha1
 	 fi
 

--- a/ktest/runtestsx.sh
+++ b/ktest/runtestsx.sh
@@ -65,7 +65,7 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
   		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -77,7 +77,7 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -85,7 +85,7 @@ installertest()
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -126,7 +126,7 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
-	 if [ PARQUET_OUTPUT -eq 1 ]; then
+	 if [ ${PARQUET_OUTPUT} -eq 1 ]; then
  		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
 	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
 	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
@@ -160,7 +160,7 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	if [ PARQUET_OUTPUT -eq 1 ]; then
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
@@ -221,7 +221,7 @@ installertest()
 
      # checksums		
 	 sha1sum -c ../$CTRL.sha1
-	 if [ PARQUET_OUTPUT -eq 1 ]; then
+	 if [ ${PARQUET_OUTPUT} -eq 1 ]; then
 		 sha1sum -c ../$CTRL_PARQUET.sha1
 	 fi
 

--- a/ktest/runtestsx.sh
+++ b/ktest/runtestsx.sh
@@ -37,7 +37,7 @@ installertest()
 	cd examples
 
 	# establish whether binaries have been linked to parquet libraries
-	if ../../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
+	if ../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
 		PARQUET_OUTPUT=1
 	fi
 
@@ -64,7 +64,7 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
   		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -76,7 +76,7 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -84,7 +84,7 @@ installertest()
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -125,7 +125,7 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
-	 if [[ -z ${PARQUET_OUTPUT} ]]; then
+	 if [[ -v PARQUET_OUTPUT ]]; then
  		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
 	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
 	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
@@ -159,7 +159,7 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	if [[ -z ${PARQUET_OUTPUT} ]]; then
+	if [[ -v PARQUET_OUTPUT ]]; then
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
@@ -220,7 +220,7 @@ installertest()
 
      # checksums		
 	 sha1sum -c ../$CTRL.sha1
-	 if [[ -z ${PARQUET_OUTPUT} ]]; then
+	 if [[ -v PARQUET_OUTPUT ]]; then
 		 sha1sum -c ../$CTRL_PARQUET.sha1
 	 fi
 

--- a/ktest/runtestsx.sh
+++ b/ktest/runtestsx.sh
@@ -37,6 +37,7 @@ installertest()
 	cd examples
 
 	# establish whether binaries have been linked to parquet libraries
+	PARQUET_OUTPUT=0
 	if ../src/katparquet/katparquet -v 2>&1 | grep -q 'Parquet output enabled'; then
 		PARQUET_OUTPUT=1
 	fi
@@ -64,7 +65,7 @@ installertest()
   	# test selt
   	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt1.csv < ../ktest/testout/gulsummarycalc1.bin
 	../src/summarycalctocsv/summarycalctocsv -o > ../ktest/testout/gulselt2.csv < ../ktest/testout/gulsummarycalc2.bin
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
   		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/summarycalctocsv/summarycalctocsv -p ../ktest/testout/gulselt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -76,7 +77,7 @@ installertest()
 	../src/eltcalc/eltcalc < ../ktest/testout/fmsummarycalc2.bin > ../ktest/testout/fmelt2.csv
 
 	# test melt qelt
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt1.parquet -q ../ktest/testout/gulqelt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/eltcalc/eltcalc -m ../ktest/testout/gulmelt2.parquet -q ../ktest/testout/gulqelt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -84,7 +85,7 @@ installertest()
 	../src/eltcalc/eltcalc -M ../ktest/testout/gulmelt2.csv -Q ../ktest/testout/gulqelt2.csv < ../ktest/testout/gulsummarycalc2.bin
 
 	# test mplt qplt splt
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt1.parquet -q ../ktest/testout/gulqplt1.parquet -s ../ktest/testout/gulsplt1.parquet < ../ktest/testout/gulsummarycalc1.bin
 		../src/pltcalc/pltcalc -m ../ktest/testout/gulmplt2.parquet -q ../ktest/testout/gulqplt2.parquet -s ../ktest/testout/gulsplt2.parquet < ../ktest/testout/gulsummarycalc2.bin
 	fi
@@ -125,7 +126,7 @@ installertest()
 	 ../src/ordleccalc/ordleccalc -r -Kgul2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/gul_ept_2_r.csv -o ../ktest/testout/gul_psept_2_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm1/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_1_r.csv -o ../ktest/testout/fm_psept_1_r.csv
 	 ../src/ordleccalc/ordleccalc -r -Kfm2/summary -F -f -W -w -M -m -S -s -O ../ktest/testout/fm_ept_2_r.csv -o ../ktest/testout/fm_psept_2_r.csv
-	 if [[ -v PARQUET_OUTPUT ]]; then
+	 if [ PARQUET_OUTPUT -eq 1 ]; then
  		../src/ordleccalc/ordleccalc  -Kgul1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_1.parquet -p ../ktest/testout/gul_psept_1.parquet
 	 	../src/ordleccalc/ordleccalc  -Kgul2/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/gul_ept_2.parquet -p ../ktest/testout/gul_psept_2.parquet
 	 	../src/ordleccalc/ordleccalc  -Kfm1/summary -F -f -W -w -M -m -S -s -P ../ktest/testout/fm_ept_1.parquet -p ../ktest/testout/fm_psept_1.parquet
@@ -159,7 +160,7 @@ installertest()
 	../src/aalcalc/aalcalc -o -Kgul2/summary > ../ktest/testout/gulalt2.csv
 	../src/aalcalc/aalcalc -o -Kfm1/summary > ../ktest/testout/fmalt1.csv
 	../src/aalcalc/aalcalc -o -Kfm2/summary > ../ktest/testout/fmalt2.csv
-	if [[ -v PARQUET_OUTPUT ]]; then
+	if [ PARQUET_OUTPUT -eq 1 ]; then
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt1.parquet -Kgul1/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/gulalt2.parquet -Kgul2/summary
 		../src/aalcalc/aalcalc -p ../ktest/testout/fmalt1.parquet -Kfm1/summary
@@ -220,7 +221,7 @@ installertest()
 
      # checksums		
 	 sha1sum -c ../$CTRL.sha1
-	 if [[ -v PARQUET_OUTPUT ]]; then
+	 if [ PARQUET_OUTPUT -eq 1 ]; then
 		 sha1sum -c ../$CTRL_PARQUET.sha1
 	 fi
 


### PR DESCRIPTION
<!--start_release_notes-->
### Suppress FATAL error messages during build process if parquet libraries have not been linked to binaries
When the relevant ktools components are not linked to parquet libraries during compilation, an error message is produced when parquet output is requested. A check for whether parquet libraries have been linked during compilation has been introduced to the build test script. Should the check fail, no parquet output will be requested. As a result, the error messages are effectively suppressed.
<!--end_release_notes-->
