### PR TITLE
Fix missing rows issue in katparquet

### DIFF
--- a/src/katparquet/katparquet.cpp
+++ b/src/katparquet/katparquet.cpp
@@ -78,9 +78,7 @@ namespace katparquet {
 	isIn[iter->second] >> rows[iter->second];
       }
 
-      if (!isIn[iter->second].eof()) {
-	GetRow(event_to_file, rows[iter->second], iter->second);
-      }
+      GetRow(event_to_file, rows[iter->second], iter->second);
 
       event_to_file.erase(iter);
 
@@ -111,9 +109,7 @@ namespace katparquet {
 	periodEventID.eventID = rows[iter->second].eventID;
       }
 
-      if (!isIn[iter->second].eof()) {
-	GetRow(period_to_file, rows[iter->second], iter->second);
-      }
+      GetRow(period_to_file, rows[iter->second], iter->second);
 
       period_to_file.erase(iter);
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix missing rows issue in katparquet
The last rows were not concatenated correctly when their event IDs (or period IDs and event IDs in the case of the Period Loss Tables) differed from those from the penultimate rows in each file. This was caused by a second end of file check that could be triggered before the last row had been read. Removing this check has solved the issue.
<!--end_release_notes-->
