### PR TITLE
Fix resizing of sample loss vector in aalcalc when sample size is 1

### DIFF
--- a/src/aalcalc/aalcalc.cpp
+++ b/src/aalcalc/aalcalc.cpp
@@ -159,15 +159,14 @@ void aalcalc::getsamplesizes()
 	// i.e. for 10 samples, sets are (1), (2, 3), (4, 5, 6, 7)
 	// for 20 samples, sets are (1), (2, 3), (4, 5, 6, 7),
 	//                          (8, 9, 10, 11, 12, 13, 14, 15)
-	if (alct_output_) {
+	if (alct_output_ && samplesize_ > 1) {
 		int i = 0;
 		while (((1 << i) + ((1 << i) - 1)) <= samplesize_) {
 			vec_sample_aal_[1 << i].resize(max_summary_id_ + 1);
 			i++;
 		}
 	}
-	if (samplesize_ != 1)
-		vec_sample_aal_[samplesize_].resize(max_summary_id_ + 1);
+	vec_sample_aal_[samplesize_].resize(max_summary_id_ + 1);
 }
 
 void aalcalc::indexevents(const std::string& fullfilename, std::string& filename) {


### PR DESCRIPTION
<!--start_release_notes-->
### Fix resizing of sample loss vector in aalcalc when sample size is 1
Following the introduction of the Average Loss Convergence Table (ALCT) in ktools v3.9.0 (see PR https://github.com/OasisLMF/ktools/pull/301 for more details) a bug was introduced where the sample loss vector in `aalcalc` would not be resized when sample size is 1 and the ALCT output was not requested on the command line. Under these circumstances, an attempt to write beyond the scope of the vector would be made, which would throw a segmentation fault. The logic behind resizing the sample loss vector has been changed, thus fixing this issue.
<!--end_release_notes-->
