### PR TITLE
Fix undetected failures from acceptance tests on non-parquet output

### DIFF
--- a/ktest/runtests.sh
+++ b/ktest/runtests.sh
@@ -33,6 +33,7 @@ installertest()
 	CTRL=ctrl
 	CTRL_PARQUET=ctrl_parquet
 	SYSTEMNAME="$(uname -s)"
+	TESTS_PASS=1
 
 	cd examples
 
@@ -259,29 +260,34 @@ installertest()
     mv footprint.idx footprintin.idx 
 	../../src/footprinttobin/footprinttobin -i 121 < footprint.csv
 
-     # checksums		
+     # checksums
+ 	SHA_SUM_EXE='sha1sum'
 	if [ "$SYSTEMNAME" == "Darwin" ]; then
-	 	shasum -c ../$CTRL.sha1
-		if [ ${PARQUET_OUTPUT} -eq 1 ]; then
-			shasum -c ../$CTRL_PARQUET.sha1
-		fi
-	else
-	 	sha1sum -c ../$CTRL.sha1
-		if [ ${PARQUET_OUTPUT} -eq 1 ]; then
-			sha1sum -c ../$CTRL_PARQUET.sha1
+		SHA_SUM_EXE='shasum'
+	fi
+	
+	$SHA_SUM_EXE -c ../$CTRL.sha1
+	if [ "$?" -ne "0" ]; then
+		TESTS_PASS=0
+	fi
+
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
+		$SHA_SUM_EXE -c ../$CTRL_PARQUET.sha1
+		if [ "$?" -ne "0" ]; then
+			TESTS_PASS=0
 		fi
 	fi
 
-	 if [ "$?" -ne "0" ]; then
-	   echo "Sorry check failed\n"
-	   cd ../..
-	   exit 1
-	 else
-	   echo "All tests passed.\n"
-	  cd ../..
-	  return
-	 fi
-	
+	if [ ${TESTS_PASS} -ne 1 ]; then
+		echo "Sorry some checks failed.\n"
+		cd ../..
+		exit 1
+	else
+		echo "All tests passed.\n"
+		cd ../..
+		return
+	fi
+
 }
 
 SCRIPT=$(readlink -f "$0")

--- a/ktest/runtestsx.sh
+++ b/ktest/runtestsx.sh
@@ -34,6 +34,7 @@ installertest()
 {
 	CTRL=ctrl
 	CTRL_PARQUET=ctrl_parquet
+	TESTS_PASS=1
 	cd examples
 
 	# establish whether binaries have been linked to parquet libraries
@@ -220,20 +221,27 @@ installertest()
 	../../src/footprinttobin/footprinttobin -i 121 < footprint.csv
 
      # checksums		
-	 sha1sum -c ../$CTRL.sha1
-	 if [ ${PARQUET_OUTPUT} -eq 1 ]; then
-		 sha1sum -c ../$CTRL_PARQUET.sha1
-	 fi
+	sha1sum -c ../$CTRL.sha1
+	if [ "$?" -ne 0 ]; then
+		TESTS_PASS=0
+	fi
 
-	 if [ "$?" -ne "0" ]; then
-	   echo "Sorry check failed\n"
-	   cd ../..
-	   exit 1
-	 else
-	   echo "All tests passed.\n"
-	  cd ../..
-	  return
-	 fi
+	if [ ${PARQUET_OUTPUT} -eq 1 ]; then
+		sha1sum -c ../$CTRL_PARQUET.sha1
+		if [ "$?" -ne 0 ]; then
+			TESTS_PASS=0
+		fi
+	fi
+
+	if [ ${TESTS_PASS} -ne 1 ]; then
+		echo "Sorry check failed.\n"
+		cd ../..
+		exit 1
+	else
+		echo "All tests passed.\n"
+		cd ../..
+		return
+	fi
 	
 }
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix undetected failures from acceptance tests on non-parquet output
Following the separation of checksums from non-parquet and parquet test outputs into two files in ktools v3.9.0, the potential for missing failures in acceptance tests of non-parquet output was introduced. This has now been fixed through changes in the testing bash scripts.
<!--end_release_notes-->
