### PR TITLE
Remove requirement for deprecated interval_type column in crossvalidation

### DIFF
--- a/src/crossvalidation/crossvalidation.cpp
+++ b/src/crossvalidation/crossvalidation.cpp
@@ -43,12 +43,14 @@ namespace crossvalidation {
     damageBins.clear();
     while(fgets(line, sizeof(line), damagebinFile) != 0) {
 
+      // No need to check for deprecated format here as this is done by
+      // validatedamagebin; the bin indexes are the only values required
 #ifdef OASIS_FLOAT_TYPE_DOUBLE
-      if(sscanf(line, "%d,%lf,%lf,%lf,%d", &d.bin_index, &d.bin_from,
-		&d.bin_to, &d.interpolation, &d.interval_type) != 5) {
+      if(sscanf(line, "%d,%lf,%lf,%lf", &d.bin_index, &d.bin_from, &d.bin_to,
+		&d.interpolation) != 4) {
 #else
-      if(sscanf(line, "%d,%f,%f,%f,%d", &d.bin_index, &d.bin_from,
-		&d.bin_to, &d.interpolation, &d.interval_type) != 5) {
+      if(sscanf(line, "%d,%f,%f,%f", &d.bin_index, &d.bin_from, &d.bin_to,
+		&d.interpolation) != 4) {
 #endif
 
 	fprintf(stderr, "File %s\n", damagebinFileName);


### PR DESCRIPTION
<!--start_release_notes-->
### Remove requirement for deprecated interval_type column in crossvalidation
The `interval_type` column in the damage bin dictionary model file has been deprecated since ktools v3.4.1. As `validatedamagebin` provides a warning should the damage bin dictionary contain the `interval_type` column, there is no need to perform a deprecated format check again in `crossvalidation`. Data is extracted from the first four columns, thus the `interval_type` column is ignored if present.
<!--end_release_notes-->
