### PR TITLE
Fix missing header in Wheatsheaf output and refactor aggreports class

### DIFF
--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -124,6 +124,7 @@ void aggreports::LoadEnsembleMapping() {
     ensembletosidx_[e.ensemble_id].push_back(e.sidx);
     i = fread(&e, sizeof(Ensemble), 1, fin);
   }
+  fclose(fin);
 
   // Check all sidx have ensemble IDs
   for (std::vector<int>::const_iterator it = std::next(sidxtoensemble.begin());

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -190,6 +190,7 @@ void aggreports::FillTVaR(std::map<wheatkey, std::vector<TVaR>> &tail,
 // epcalc = sidx for Wheatsheaf (Per Sample Exceedance Probability Table)
 // TODO: There is probably a tidier way of doing this.
 #ifdef ORD_OUTPUT
+template<typename T>
 void aggreports::WriteReturnPeriodOut(const std::vector<int> &fileIDs,
 	size_t &nextreturnperiod_index, double &last_return_period,
 	OASIS_FLOAT &last_loss, const double current_return_period,

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -190,26 +190,25 @@ void aggreports::FillTVaR(std::map<wheatkey, std::vector<TVaR>> &tail,
 // epcalc = sidx for Wheatsheaf (Per Sample Exceedance Probability Table)
 // TODO: There is probably a tidier way of doing this.
 #ifdef ORD_OUTPUT
-template<typename T>
-void aggreports::WriteReturnPeriodOut(const std::vector<int> fileIDs,
+void aggreports::WriteReturnPeriodOut(const std::vector<int> &fileIDs,
 	size_t &nextreturnperiod_index, double &last_return_period,
 	OASIS_FLOAT &last_loss, const double current_return_period,
 	const OASIS_FLOAT current_loss, const int summary_id, const int eptype,
 	const int epcalc, const double max_retperiod, int counter,
 	OASIS_FLOAT tvar, T &tail,
-	void (aggreports::*WriteOutput)(const std::vector<int>, const int,
+	void (aggreports::*WriteOutput)(const std::vector<int>&, const int,
 					const int, const int, const double,
 					const OASIS_FLOAT),
 	parquet::StreamWriter& os)
 #else
 template<typename T>
-void aggreports::WriteReturnPeriodOut(const std::vector<int> fileIDs,
+void aggreports::WriteReturnPeriodOut(const std::vector<int> &fileIDs,
 	size_t &nextreturnperiod_index, double &last_return_period,
 	OASIS_FLOAT &last_loss, const double current_return_period,
 	const OASIS_FLOAT current_loss, const int summary_id, const int eptype,
 	const int epcalc, const double max_retperiod, int counter,
 	OASIS_FLOAT tvar, T &tail,
-	void (aggreports::*WriteOutput)(const std::vector<int>, const int,
+	void (aggreports::*WriteOutput)(const std::vector<int>&, const int,
 					const int, const int, const double,
 					const OASIS_FLOAT))
 #endif
@@ -262,7 +261,7 @@ void aggreports::WriteReturnPeriodOut(const std::vector<int> fileIDs,
 }
 
 
-inline void aggreports::OutputRows(const std::vector<int> fileIDs,
+inline void aggreports::OutputRows(const std::vector<int> &fileIDs,
 				   const char * buffer, int strLen) {
 
   for (std::vector<int>::const_iterator it = fileIDs.begin();
@@ -298,7 +297,7 @@ inline void aggreports::OutputRows(const std::vector<int> fileIDs,
 }
 
 
-void aggreports::WriteLegacyOutput(const std::vector<int> fileIDs,
+void aggreports::WriteLegacyOutput(const std::vector<int> &fileIDs,
 				   const int summary_id, const int type,
 				   const int ensemble_id,
 				   const double retperiod,
@@ -318,7 +317,7 @@ void aggreports::WriteLegacyOutput(const std::vector<int> fileIDs,
 }
 
 
-void aggreports::WriteORDOutput(const std::vector<int> fileIDs,
+void aggreports::WriteORDOutput(const std::vector<int> &fileIDs,
 				const int summary_id, const int epcalc,
 				const int eptype, const double retperiod,
 				const OASIS_FLOAT loss) {
@@ -333,7 +332,7 @@ void aggreports::WriteORDOutput(const std::vector<int> fileIDs,
 }
 
 
-void aggreports::WriteTVaR(const std::vector<int> fileIDs, const int epcalc,
+void aggreports::WriteTVaR(const std::vector<int> &fileIDs, const int epcalc,
 			   const int eptype_tvar,
 			   const std::map<int, std::vector<TVaR>> &tail) {
 
@@ -353,7 +352,7 @@ void aggreports::WriteTVaR(const std::vector<int> fileIDs, const int epcalc,
 }
 
 
-void aggreports::WriteTVaR(const std::vector<int> fileIDs,
+void aggreports::WriteTVaR(const std::vector<int> &fileIDs,
 			   const int eptype_tvar,
 			   const std::map<wheatkey, std::vector<TVaR>> &tail) {
 
@@ -443,7 +442,7 @@ inline parquet::StreamWriter aggreports::GetParquetStreamWriter(const int fileSt
 
 inline void aggreports::DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
 	const std::vector<int> fileIDs,
-	void (aggreports::*&WriteOutput)(const std::vector<int>, const int,
+	void (aggreports::*&WriteOutput)(const std::vector<int>&, const int,
 					 const int, const int, const double,
 					 const OASIS_FLOAT))
 {
@@ -476,7 +475,7 @@ void aggreports::WriteExceedanceProbabilityTable(
   if (samplesize == 0) return;
 
 //  int eptype_tvar = 0;
-  void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
+  void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
   DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
@@ -582,7 +581,7 @@ void aggreports::WriteExceedanceProbabilityTable(
   if (samplesize == 0) return;
 
 //  int eptype_tvar = 0;
-  void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
+  void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
   DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
@@ -696,7 +695,7 @@ void aggreports::WriteExceedanceProbabilityTable(
 
 inline void aggreports::DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
 	const std::vector<int> fileIDs,
-	void (aggreports::*&WriteOutput)(const std::vector<int>, const int,
+	void (aggreports::*&WriteOutput)(const std::vector<int>&, const int,
 					 const int, const int, const double,
 					 const OASIS_FLOAT))
 {
@@ -719,7 +718,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
   if (items.size() == 0) return;
 
 //  int eptype_tvar = 0;
-  void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
+  void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
   DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
@@ -823,7 +822,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
   if (items.size() == 0) return;
 
 //  int eptype_tvar = 0;
-  void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
+  void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
   DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -448,15 +448,12 @@ inline parquet::StreamWriter aggreports::GetParquetStreamWriter(const int fileSt
 #endif
 
 
-inline void aggreports::DoSetUp(int &eptype, int &eptype_tvar, int &epcalc,
-	const int ensemble_id, const std::vector<int> fileIDs,
+inline void aggreports::DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
+	const std::vector<int> fileIDs,
 	void (aggreports::*&WriteOutput)(const std::vector<int>, const int,
 					 const int, const int, const double,
 					 const OASIS_FLOAT))
 {
-
-  if (eptype == AEP) eptype_tvar = AEPTVAR;
-  else if (eptype == OEP) eptype_tvar = OEPTVAR;
 
   if (ordFlag_) {
     WriteOutput = &aggreports::WriteORDOutput;
@@ -480,16 +477,16 @@ inline void aggreports::DoSetUp(int &eptype, int &eptype_tvar, int &epcalc,
 // No weighting
 void aggreports::WriteExceedanceProbabilityTable(
 	const std::vector<int> fileIDs, std::map<int, lossvec> &items,
-	const double max_retperiod, int epcalc, int eptype, int samplesize,
-	int ensemble_id) {
+	const double max_retperiod, int epcalc, int eptype, int eptype_tvar,
+	int samplesize,	int ensemble_id) {
 
   if (items.size() == 0) return;
   if (samplesize == 0) return;
 
-  int eptype_tvar = 0;
+//  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
-  DoSetUp(eptype, eptype_tvar, epcalc, ensemble_id, fileIDs, WriteOutput);
+  DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_ept_exists_ == false) {
@@ -582,17 +579,17 @@ void aggreports::WriteExceedanceProbabilityTable(
 void aggreports::WriteExceedanceProbabilityTable(
 	const std::vector<int> fileIDs, std::map<int, lossvec2> &items,
 	const OASIS_FLOAT cum_weight_constant,
-	int epcalc, int eptype,
+	int epcalc, int eptype, int eptype_tvar,
 	std::map<int, double> &unusedperiodstoweighting, int samplesize,
 	int ensemble_id) {
 
   if (items.size() == 0) return;
   if (samplesize == 0) return;
 
-  int eptype_tvar = 0;
+//  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
-  DoSetUp(eptype, eptype_tvar, epcalc, ensemble_id, fileIDs, WriteOutput);
+  DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_ept_exists_ == false) {
@@ -699,15 +696,12 @@ void aggreports::WriteExceedanceProbabilityTable(
 }
 
 
-inline void aggreports::DoSetUpWheatsheaf(int &eptype, int &eptype_tvar,
-	const int ensemble_id, const std::vector<int> fileIDs,
+inline void aggreports::DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
+	const std::vector<int> fileIDs,
 	void (aggreports::*&WriteOutput)(const std::vector<int>, const int,
 					 const int, const int, const double,
 					 const OASIS_FLOAT))
 {
-
-  if (eptype == AEP) eptype_tvar = AEPTVAR;
-  else if (eptype == OEP) eptype_tvar = OEPTVAR;
 
   if (ordFlag_) {
     WriteOutput = &aggreports::WriteORDOutput;
@@ -723,14 +717,14 @@ inline void aggreports::DoSetUpWheatsheaf(int &eptype, int &eptype_tvar,
 // No weighting
 void aggreports::WritePerSampleExceedanceProbabilityTable(
 	const std::vector<int> fileIDs, std::map<wheatkey, lossvec> &items,
-	int eptype, int ensemble_id) {
+	int eptype, int eptype_tvar, int ensemble_id) {
 
   if (items.size() == 0) return;
 
-  int eptype_tvar = 0;
+//  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
-  DoSetUpWheatsheaf(eptype, eptype_tvar, ensemble_id, fileIDs, WriteOutput);
+  DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_psept_exists_ == false) {
@@ -823,15 +817,15 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 // With weighting
 void aggreports::WritePerSampleExceedanceProbabilityTable(
 	const std::vector<int> fileIDs, std::map<wheatkey, lossvec2> &items,
-	int eptype, std::map<int, double> &unusedperiodstoweighting,
-	int ensemble_id) {
+	int eptype, int eptype_tvar,
+	std::map<int, double> &unusedperiodstoweighting, int ensemble_id) {
 
   if (items.size() == 0) return;
 
-  int eptype_tvar = 0;
+//  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
-  DoSetUpWheatsheaf(eptype, eptype_tvar, ensemble_id, fileIDs, WriteOutput);
+  DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_psept_exists_ == false) {
@@ -940,7 +934,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 
 void aggreports::MeanDamageRatio(const std::vector<int> fileIDs,
 				 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-				 const int eptype) {
+				 const int eptype, const int eptype_tvar) {
 
   std::map<int, lossvec> items;
 
@@ -949,13 +943,14 @@ void aggreports::MeanDamageRatio(const std::vector<int> fileIDs,
   }
 
   WriteExceedanceProbabilityTable(fileIDs, items, totalperiods_, MEANDR,
-				  eptype);
+				  eptype, eptype_tvar);
 
 }
 
 
 void aggreports::MeanDamageRatioWithWeighting(const std::vector<int> fileIDs,
-	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype) {
+	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
+	const int eptype_tvar) {
 
   std::map<int, lossvec2> items;
   std::map<int, double> unusedperiodstoweighting = periodstoweighting_;
@@ -973,7 +968,7 @@ void aggreports::MeanDamageRatioWithWeighting(const std::vector<int> fileIDs,
   }
 
   WriteExceedanceProbabilityTable(fileIDs, items, samplesize_, MEANDR, eptype,
-				  unusedperiodstoweighting);
+				  eptype_tvar, unusedperiodstoweighting);
 
 }
 
@@ -983,11 +978,11 @@ void aggreports::OutputMeanDamageRatio(const int eptype, const int eptype_tvar,
 				       std::vector<int> &fileIDs) {
 
   if (periodstoweighting_.size() == 0) {
-    MeanDamageRatio(fileIDs, GetOutLoss, eptype);
+    MeanDamageRatio(fileIDs, GetOutLoss, eptype, eptype_tvar);
     return;
   }
 
-  MeanDamageRatioWithWeighting(fileIDs, GetOutLoss, eptype);
+  MeanDamageRatioWithWeighting(fileIDs, GetOutLoss, eptype, eptype_tvar);
 
 }
 
@@ -1009,7 +1004,7 @@ inline std::vector<int> aggreports::GetFileIDs(const int handle, int table) {
 
 void aggreports::FullUncertainty(const std::vector<int> fileIDs,
 				 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-				 const int eptype) {
+				 const int eptype, const int eptype_tvar) {
 
   std::map<int, lossvec> items;
 
@@ -1018,7 +1013,7 @@ void aggreports::FullUncertainty(const std::vector<int> fileIDs,
   }
 
   WriteExceedanceProbabilityTable(fileIDs, items, totalperiods_ * samplesize_,
-				  FULL, eptype);
+				  FULL, eptype, eptype_tvar);
 
   // By ensemble ID
   if (ordFlag_) return;   // Ensemble IDs not supported for ORD output
@@ -1034,7 +1029,8 @@ void aggreports::FullUncertainty(const std::vector<int> fileIDs,
       }
       WriteExceedanceProbabilityTable(fileIDs, items,
 				      totalperiods_ * ensemble.second.size(),
-				      FULL, eptype, 1, ensemble.first);
+				      FULL, eptype, eptype_tvar, 1,
+				      ensemble.first);
     }
   }
 
@@ -1042,7 +1038,8 @@ void aggreports::FullUncertainty(const std::vector<int> fileIDs,
 
 
 void aggreports::FullUncertaintyWithWeighting(const std::vector<int> fileIDs,
-	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype) {
+	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
+	const int eptype_tvar) {
 
   std::map<int, lossvec2> items;
   std::map<int, double> unusedperiodstoweighting = periodstoweighting_;
@@ -1059,7 +1056,7 @@ void aggreports::FullUncertaintyWithWeighting(const std::vector<int> fileIDs,
     unusedperiodstoweighting.erase(x.first.period_no);
   }
 
-  WriteExceedanceProbabilityTable(fileIDs, items, 1, FULL, eptype,
+  WriteExceedanceProbabilityTable(fileIDs, items, 1, FULL, eptype, eptype_tvar,
 				  unusedperiodstoweighting);
 
   // By ensemble ID
@@ -1084,7 +1081,7 @@ void aggreports::FullUncertaintyWithWeighting(const std::vector<int> fileIDs,
 	}
       }
       WriteExceedanceProbabilityTable(fileIDs, items, 1, FULL, eptype,
-				      unusedperiodstoweighting, 1,
+				      eptype_tvar, unusedperiodstoweighting, 1,
 				      ensemble.first);
     }
   }
@@ -1101,11 +1098,11 @@ void aggreports::OutputFullUncertainty(const int handle, const int eptype,
   std::vector<int> fileIDs = GetFileIDs(handle);
 
   if (periodstoweighting_.size() == 0) {
-    FullUncertainty(fileIDs, GetOutLoss, eptype);
+    FullUncertainty(fileIDs, GetOutLoss, eptype, eptype_tvar);
     return;
   }
 
-  FullUncertainty(fileIDs, GetOutLoss, eptype);
+  FullUncertainty(fileIDs, GetOutLoss, eptype, eptype_tvar);
 
 }
 
@@ -1150,7 +1147,8 @@ inline void aggreports::FillWheatsheafItems(const outkey2 key,
 // Wheatsheaf Mean = Per Sample Mean (Exceedance Probability Table)
 void aggreports::WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 				OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-				const int eptype, const int ensemble_id) {
+				const int eptype, int eptype_tvar,
+				const int ensemble_id) {
 
   std::map<wheatkey, lossvec> items;
   int samplesize;
@@ -1174,7 +1172,7 @@ void aggreports::WheatsheafAndWheatsheafMean(const std::vector<int> handles,
   if (outputFlags_[handles[WHEATSHEAF]] == true) {
     std::vector<int> fileIDs = GetFileIDs(handles[WHEATSHEAF], PSEPT);
     WritePerSampleExceedanceProbabilityTable(fileIDs, items, eptype,
-					     ensemble_id);
+					     eptype_tvar, ensemble_id);
   }
 
   if (outputFlags_[handles[WHEATSHEAF_MEAN]] == false) return;
@@ -1204,8 +1202,8 @@ void aggreports::WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 
   std::vector<int> fileIDs = GetFileIDs(handles[WHEATSHEAF_MEAN]);
   WriteExceedanceProbabilityTable(fileIDs, mean_map, totalperiods_,
-				  PERSAMPLEMEAN, eptype, samplesize,
-				  ensemble_id);
+				  PERSAMPLEMEAN, eptype, eptype_tvar,
+				  samplesize, ensemble_id);
 
 }
 
@@ -1214,7 +1212,7 @@ void aggreports::WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 // Wheatsheaf Mean = Per Sample Mean (Exceedance Probability Table)
 void aggreports::WheatsheafAndWheatsheafMeanWithWeighting(
 	const std::vector<int> handles, OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-	const int eptype, const int ensemble_id) {
+	const int eptype, const int eptype_tvar, const int ensemble_id) {
 
   std::map<wheatkey, lossvec2> items;
   int samplesize;
@@ -1242,6 +1240,7 @@ void aggreports::WheatsheafAndWheatsheafMeanWithWeighting(
   if (outputFlags_[handles[WHEATSHEAF]] == true) {
     std::vector<int> fileIDs = GetFileIDs(handles[WHEATSHEAF], PSEPT);
     WritePerSampleExceedanceProbabilityTable(fileIDs, items, eptype,
+					     eptype_tvar,
 					     unusedperiodstoweighting,
 					     ensemble_id);
   }
@@ -1267,7 +1266,7 @@ void aggreports::WheatsheafAndWheatsheafMeanWithWeighting(
 
   std::vector<int> fileIDs = GetFileIDs(handles[WHEATSHEAF_MEAN]);
   WriteExceedanceProbabilityTable(fileIDs, mean_map, samplesize,
-				  PERSAMPLEMEAN, eptype,
+				  PERSAMPLEMEAN, eptype, eptype_tvar,
 				  unusedperiodstoweighting, samplesize,
 				  ensemble_id);
 
@@ -1286,9 +1285,10 @@ void aggreports::OutputWheatsheafAndWheatsheafMean(const std::vector<int> &handl
   if (falseCount == 2) return;
 
   if (periodstoweighting_.size() == 0) {
-    WheatsheafAndWheatsheafMean(handles, GetOutLoss, eptype);
+    WheatsheafAndWheatsheafMean(handles, GetOutLoss, eptype, eptype_tvar);
   } else {
-    WheatsheafAndWheatsheafMeanWithWeighting(handles, GetOutLoss, eptype);
+    WheatsheafAndWheatsheafMeanWithWeighting(handles, GetOutLoss, eptype,
+					     eptype_tvar);
   }
 
   // By ensemble ID
@@ -1296,11 +1296,11 @@ void aggreports::OutputWheatsheafAndWheatsheafMean(const std::vector<int> &handl
   if (ensembletosidx_.size() > 0) {
     for (auto ensemble : ensembletosidx_) {
       if (periodstoweighting_.size() == 0) {
-	WheatsheafAndWheatsheafMean(handles, GetOutLoss, eptype,
+	WheatsheafAndWheatsheafMean(handles, GetOutLoss, eptype, eptype_tvar,
 				    ensemble.first);
       } else {
 	WheatsheafAndWheatsheafMeanWithWeighting(handles, GetOutLoss, eptype,
-						 ensemble.first);
+						 eptype_tvar, ensemble.first);
       }
     }
   }
@@ -1310,7 +1310,7 @@ void aggreports::OutputWheatsheafAndWheatsheafMean(const std::vector<int> &handl
 
 void aggreports::SampleMean(const std::vector<int> fileIDs,
 			    OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			    const int eptype) {
+			    const int eptype, const int eptype_tvar) {
 
   if (samplesize_ == 0) return;   // Prevent division by zero error
 
@@ -1328,7 +1328,7 @@ void aggreports::SampleMean(const std::vector<int> fileIDs,
   }
 
   WriteExceedanceProbabilityTable(fileIDs, mean_map, totalperiods_, MEANSAMPLE,
-				  eptype);
+				  eptype, eptype_tvar);
 
   // By ensemble ID
   if (ordFlag_) return;   // Ensemble IDs not supported for ORD output
@@ -1350,7 +1350,8 @@ void aggreports::SampleMean(const std::vector<int> fileIDs,
 	mean_map[s.first.summary_id].push_back(s.second);
       }
       WriteExceedanceProbabilityTable(fileIDs, mean_map, totalperiods_,
-				      MEANSAMPLE, eptype, 1, ensemble.first);
+				      MEANSAMPLE, eptype, eptype_tvar, 1,
+				      ensemble.first);
     }
   }
 
@@ -1358,7 +1359,8 @@ void aggreports::SampleMean(const std::vector<int> fileIDs,
 
 
 void aggreports::SampleMeanWithWeighting(const std::vector<int> fileIDs,
-	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype) {
+	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
+	const int eptype_tvar) {
 
   if (samplesize_ == 0) return;   // Prevent division by zero error
 
@@ -1384,7 +1386,8 @@ void aggreports::SampleMeanWithWeighting(const std::vector<int> fileIDs,
   }
 
   WriteExceedanceProbabilityTable(fileIDs, mean_map, samplesize_, MEANSAMPLE,
-				  eptype, unusedperiodstoweighting);
+				  eptype, eptype_tvar,
+				  unusedperiodstoweighting);
 
   // By ensemble ID
   if (ordFlag_) return;   // Ensemble IDs not supported for ORD output
@@ -1413,7 +1416,7 @@ void aggreports::SampleMeanWithWeighting(const std::vector<int> fileIDs,
 	mean_map[s.first.summary_id].push_back(s.second);
       }
       WriteExceedanceProbabilityTable(fileIDs, mean_map, samplesize_,
-				      MEANSAMPLE, eptype,
+				      MEANSAMPLE, eptype, eptype_tvar,
 				      unusedperiodstoweighting, 1,
 				      ensemble.first);
     }
@@ -1430,10 +1433,10 @@ void aggreports::OutputSampleMean(const int handle, const int eptype,
   std::vector<int> fileIDs = GetFileIDs(handle);
 
   if (periodstoweighting_.size() == 0) {
-    SampleMean(fileIDs, GetOutLoss, eptype);
+    SampleMean(fileIDs, GetOutLoss, eptype, eptype_tvar);
     return;
   }
 
-  SampleMeanWithWeighting(fileIDs, GetOutLoss, eptype);
+  SampleMeanWithWeighting(fileIDs, GetOutLoss, eptype, eptype_tvar);
 
 }

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -441,7 +441,6 @@ inline parquet::StreamWriter aggreports::GetParquetStreamWriter(const int fileSt
 
 
 inline void aggreports::DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
-	const std::vector<int> fileIDs,
 	void (aggreports::*&WriteOutput)(const std::vector<int>&, const int,
 					 const int, const int, const double,
 					 const OASIS_FLOAT))
@@ -467,7 +466,7 @@ inline void aggreports::DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
 
 // No weighting
 void aggreports::WriteExceedanceProbabilityTable(
-	const std::vector<int> fileIDs, std::map<int, lossvec> &items,
+	const std::vector<int> &fileIDs, std::map<int, lossvec> &items,
 	const double max_retperiod, int epcalc, int eptype, int eptype_tvar,
 	int samplesize,	int ensemble_id) {
 
@@ -478,7 +477,7 @@ void aggreports::WriteExceedanceProbabilityTable(
   void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
-  DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
+  DoSetUp(eptype, epcalc, ensemble_id, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_ept_exists_ == false) {
@@ -571,7 +570,7 @@ void aggreports::WriteExceedanceProbabilityTable(
 
 // With weighting
 void aggreports::WriteExceedanceProbabilityTable(
-	const std::vector<int> fileIDs, std::map<int, lossvec2> &items,
+	const std::vector<int> &fileIDs, std::map<int, lossvec2> &items,
 	const OASIS_FLOAT cum_weight_constant,
 	int epcalc, int eptype, int eptype_tvar,
 	std::map<int, double> &unusedperiodstoweighting, int samplesize,
@@ -584,7 +583,7 @@ void aggreports::WriteExceedanceProbabilityTable(
   void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
-  DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
+  DoSetUp(eptype, epcalc, ensemble_id, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_ept_exists_ == false) {
@@ -694,7 +693,6 @@ void aggreports::WriteExceedanceProbabilityTable(
 
 
 inline void aggreports::DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
-	const std::vector<int> fileIDs,
 	void (aggreports::*&WriteOutput)(const std::vector<int>&, const int,
 					 const int, const int, const double,
 					 const OASIS_FLOAT))
@@ -712,7 +710,7 @@ inline void aggreports::DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
 
 // No weighting
 void aggreports::WritePerSampleExceedanceProbabilityTable(
-	const std::vector<int> fileIDs, std::map<wheatkey, lossvec> &items,
+	const std::vector<int> &fileIDs, std::map<wheatkey, lossvec> &items,
 	int eptype, int eptype_tvar, int ensemble_id) {
 
   if (items.size() == 0) return;
@@ -721,7 +719,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
   void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
-  DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
+  DoSetUpWheatsheaf(eptype, ensemble_id, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_psept_exists_ == false) {
@@ -815,7 +813,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 
 // With weighting
 void aggreports::WritePerSampleExceedanceProbabilityTable(
-	const std::vector<int> fileIDs, std::map<wheatkey, lossvec2> &items,
+	const std::vector<int> &fileIDs, std::map<wheatkey, lossvec2> &items,
 	int eptype, int eptype_tvar,
 	std::map<int, double> &unusedperiodstoweighting, int ensemble_id) {
 
@@ -825,7 +823,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
   void (aggreports::*WriteOutput)(const std::vector<int>&, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
   WriteOutput = nullptr;
-  DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
+  DoSetUpWheatsheaf(eptype, ensemble_id, WriteOutput);
 
 #ifdef ORD_OUTPUT
   if (os_psept_exists_ == false) {
@@ -934,7 +932,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 }
 
 
-void aggreports::MeanDamageRatio(const std::vector<int> fileIDs,
+void aggreports::MeanDamageRatio(const std::vector<int> &fileIDs,
 				 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 				 const int eptype, const int eptype_tvar) {
 
@@ -950,7 +948,7 @@ void aggreports::MeanDamageRatio(const std::vector<int> fileIDs,
 }
 
 
-void aggreports::MeanDamageRatioWithWeighting(const std::vector<int> fileIDs,
+void aggreports::MeanDamageRatioWithWeighting(const std::vector<int> &fileIDs,
 	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
 	const int eptype_tvar) {
 
@@ -1004,7 +1002,7 @@ inline std::vector<int> aggreports::GetFileIDs(const int handle, int table) {
 }
 
 
-void aggreports::FullUncertainty(const std::vector<int> fileIDs,
+void aggreports::FullUncertainty(const std::vector<int> &fileIDs,
 				 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 				 const int eptype, const int eptype_tvar) {
 
@@ -1039,7 +1037,7 @@ void aggreports::FullUncertainty(const std::vector<int> fileIDs,
 }
 
 
-void aggreports::FullUncertaintyWithWeighting(const std::vector<int> fileIDs,
+void aggreports::FullUncertaintyWithWeighting(const std::vector<int> &fileIDs,
 	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
 	const int eptype_tvar) {
 
@@ -1310,7 +1308,7 @@ void aggreports::OutputWheatsheafAndWheatsheafMean(const std::vector<int> &handl
 }
 
 
-void aggreports::SampleMean(const std::vector<int> fileIDs,
+void aggreports::SampleMean(const std::vector<int> &fileIDs,
 			    OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 			    const int eptype, const int eptype_tvar) {
 
@@ -1360,7 +1358,7 @@ void aggreports::SampleMean(const std::vector<int> fileIDs,
 }
 
 
-void aggreports::SampleMeanWithWeighting(const std::vector<int> fileIDs,
+void aggreports::SampleMeanWithWeighting(const std::vector<int> &fileIDs,
 	OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
 	const int eptype_tvar) {
 

--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -232,8 +232,10 @@ void aggreports::WriteReturnPeriodOut(const std::vector<int> fileIDs,
 
     OASIS_FLOAT loss = GetLoss(nextreturnperiod_value, last_return_period,
 			       last_loss, current_return_period, current_loss);
-    (this->*WriteOutput)(fileIDs, summary_id, epcalc, eptype,
-			 nextreturnperiod_value, loss);
+    if (WriteOutput != nullptr) {
+    	(this->*WriteOutput)(fileIDs, summary_id, epcalc, eptype,
+			     nextreturnperiod_value, loss);
+    }
 #ifdef ORD_OUTPUT
     if (parquetFileNames_[EPT] != "") {
       WriteParquetOutput(os, summary_id, epcalc, eptype,
@@ -328,15 +330,6 @@ void aggreports::WriteORDOutput(const std::vector<int> fileIDs,
 		    eptype, retperiod, loss);
   OutputRows(fileIDs, buffer, strLen);
 
-}
-
-
-void aggreports::WriteNoOutput(const std::vector<int> fileIDs,
-			       const int summary_id, const int epcalc,
-			       const int eptype, const double retperiod,
-			       const OASIS_FLOAT loss)
-{
-  return;
 }
 
 
@@ -457,7 +450,6 @@ inline void aggreports::DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
 
   if (ordFlag_) {
     WriteOutput = &aggreports::WriteORDOutput;
-    if (fileIDs.size() == 0) WriteOutput = &aggreports::WriteNoOutput;
   } else {
     WriteOutput = &aggreports::WriteLegacyOutput;
     // epcalc = type in legacy output
@@ -486,6 +478,7 @@ void aggreports::WriteExceedanceProbabilityTable(
 //  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
+  WriteOutput = nullptr;
   DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
@@ -527,8 +520,10 @@ void aggreports::WriteExceedanceProbabilityTable(
       } else {
 	tvar = tvar - ((tvar - (lp / samplesize)) / i);
 	tail[s.first].push_back({retperiod, tvar});
-	(this->*WriteOutput)(fileIDs, s.first, epcalc, eptype, retperiod,
-			     lp / samplesize);
+	if (WriteOutput != nullptr) {
+	  (this->*WriteOutput)(fileIDs, s.first, epcalc, eptype, retperiod,
+			       lp / samplesize);
+	}
 #ifdef ORD_OUTPUT
 	// TODO: Rather than checking for this on every iteration, it may be
 	// more efficient to create a new class that inherits from
@@ -589,6 +584,7 @@ void aggreports::WriteExceedanceProbabilityTable(
 //  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
+  WriteOutput = nullptr;
   DoSetUp(eptype, epcalc, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
@@ -642,8 +638,10 @@ void aggreports::WriteExceedanceProbabilityTable(
 	} else {
 	  tvar = tvar - ((tvar - (lp.value / samplesize)) / i);
 	  tail[s.first].push_back({retperiod, tvar});
-	  (this->*WriteOutput)(fileIDs, s.first, epcalc, eptype, retperiod,
-			       lp.value / samplesize);
+	  if (WriteOutput != nullptr) {
+	    (this->*WriteOutput)(fileIDs, s.first, epcalc, eptype, retperiod,
+				 lp.value / samplesize);
+	  }
 #ifdef ORD_OUTPUT
 	// TODO: Rather than checking for this on every iteration, it may be
 	// more efficient to create a new class that inherits from
@@ -705,7 +703,6 @@ inline void aggreports::DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
 
   if (ordFlag_) {
     WriteOutput = &aggreports::WriteORDOutput;
-    if (fileIDs.size() == 0) WriteOutput = &aggreports::WriteNoOutput;
   } else {
     WriteOutput = &aggreports::WriteLegacyOutput;
     eptype = ensemble_id;
@@ -724,6 +721,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 //  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
+  WriteOutput = nullptr;
   DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
@@ -767,8 +765,10 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
       } else {
 	tvar = tvar - ((tvar - lp) / i);
 	tail[s.first].push_back({retperiod, tvar});
-	(this->*WriteOutput)(fileIDs, s.first.summary_id, s.first.sidx, eptype,
-			     retperiod, lp);
+	if (WriteOutput != nullptr) {
+	  (this->*WriteOutput)(fileIDs, s.first.summary_id, s.first.sidx,
+			       eptype, retperiod, lp);
+	}
 #ifdef ORD_OUTPUT
 	// TODO: Rather than checking for this on every iteration, it may be
 	// more efficient to create a new class that inherits from
@@ -825,6 +825,7 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 //  int eptype_tvar = 0;
   void (aggreports::*WriteOutput)(const std::vector<int>, const int, const int,
 				  const int, const double, const OASIS_FLOAT);
+  WriteOutput = nullptr;
   DoSetUpWheatsheaf(eptype, ensemble_id, fileIDs, WriteOutput);
 
 #ifdef ORD_OUTPUT
@@ -879,8 +880,10 @@ void aggreports::WritePerSampleExceedanceProbabilityTable(
 	} else {
 	  tvar = tvar - ((tvar - lp.value) / i);
 	  tail[s.first].push_back({retperiod, tvar});
-	  (this->*WriteOutput)(fileIDs, s.first.summary_id, s.first.sidx,
-			       eptype, retperiod, lp.value);
+	  if (WriteOutput != nullptr) {
+	    (this->*WriteOutput)(fileIDs, s.first.summary_id, s.first.sidx,
+				 eptype, retperiod, lp.value);
+	  }
 #ifdef ORD_OUTPUT
 	// TODO: Rather than checking for this on every iteration, it may be
 	// more efficient to create a new class that inherits from

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -49,7 +49,6 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 #endif
 
 enum { MEANDR = 1, FULL, PERSAMPLEMEAN, MEANSAMPLE };
-enum { OEP = 1, OEPTVAR, AEP, AEPTVAR };
 enum { MEANS = 0, SAMPLES };
 enum { WHEATSHEAF = 0, WHEATSHEAF_MEAN };
 
@@ -236,13 +235,26 @@ private:
 
 public:
 	aggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool *outputFlags, const bool ordFlag, const std::string *parquetFileNames);
-	void OutputAggMeanDamageRatio();
-	void OutputOccMeanDamageRatio();
-	void OutputAggFullUncertainty();
-	void OutputOccFullUncertainty();
-	void OutputAggWheatsheafAndWheatsheafMean();
-	void OutputOccWheatsheafAndWheatsheafMean();
-	void OutputAggSampleMean();
-	void OutputOccSampleMean();
+	void OutputMeanDamageRatio(const int eptype, const int eptype_tvar,
+				   OASIS_FLOAT (OutLosses::*GetOutLoss)(),
+				   std::vector<int> &fileIDs);
+	void OutputFullUncertainty(const int handle, const int eptype,
+				   const int eptype_tvar,
+				   OASIS_FLOAT (OutLosses::*GetOutLoss)());
+	void OutputWheatsheafAndWheatsheafMean(const std::vector<int> &handles,
+						const int eptype,
+						const int eptype_tvar,
+						OASIS_FLOAT (OutLosses::*GetOutLoss)());
+	void OutputSampleMean(const int handle, const int eptype,
+			      const int eptype_tvar,
+			      OASIS_FLOAT (OutLosses::*GetOutLoss)());
+//	void OutputAggMeanDamageRatio();
+//	void OutputOccMeanDamageRatio();
+//	void OutputAggFullUncertainty();
+//	void OutputOccFullUncertainty();
+//	void OutputAggWheatsheafAndWheatsheafMean();
+//	void OutputOccWheatsheafAndWheatsheafMean();
+//	void OutputAggSampleMean();
+//	void OutputOccSampleMean();
 };
 #endif // AGGREPORTS_H_

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -170,7 +170,7 @@ private:
 			      const std::map<wheatkey, std::vector<TVaR>> &tail);
 	inline parquet::StreamWriter GetParquetStreamWriter(const int fileStream);
 #endif
-	inline void DoSetUp(int &eptype, int &epcalc, const int ensemble_id);
+	inline void DoSetUp(int &eptype, const int ensemble_id);
 	void WriteExceedanceProbabilityTable(const std::vector<int> &fileIDs,
 					     std::map<int, lossvec> &items,
 					     const double max_retperiod,
@@ -183,7 +183,6 @@ private:
 		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
 		int samplesize=1, int ensemble_id=0);
-	inline void DoSetUpWheatsheaf(int &eptype, const int ensemble_id);
 	void WritePerSampleExceedanceProbabilityTable(
 		const std::vector<int> &fileIDs,
 		std::map<wheatkey, lossvec> &items, int eptype, int eptype_tvar,
@@ -196,17 +195,19 @@ private:
 		int ensemble_id=0);
 	void MeanDamageRatio(const std::vector<int> &fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			     const int eptype, const int eptype_tvar);
+			     const int epcalc, const int eptype,
+			     const int eptype_tvar);
 	void MeanDamageRatioWithWeighting(const std::vector<int> &fileIDs,
-		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
-		const int eptype_tvar);
+		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int epcalc,
+		const int eptype, const int eptype_tvar);
 	inline std::vector<int> GetFileIDs(const int handle, int table=EPT);
 	void FullUncertainty(const std::vector<int> &fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			     const int eptype, const int eptype_tvar);
+			     const int epcalc, const int eptype,
+			     const int eptype_tvar);
 	void FullUncertaintyWithWeighting(const std::vector<int> &fileIDs,
-		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
-		const int eptype_tvar);
+		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int epcalc,
+		const int eptype, const int eptype_tvar);
 	inline void FillWheatsheafItems(const outkey2 key,
 					std::map<wheatkey, lossvec> &items,
 					const OASIS_FLOAT loss);
@@ -217,19 +218,22 @@ private:
 					std::map<int, double> &unusedperiodstoweighting);
 	void WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 					 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-					 const int eptype,
+					 const int epcalc, const int eptype,
 					 const int eptype_tvar,
 					 const int ensemble_id=0);
 	void WheatsheafAndWheatsheafMeanWithWeighting(
 		const std::vector<int> handles,
-		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
-		const int eptype_tvar, const int ensemble_id=0);
+		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int epcalc,
+		const int eptype, const int eptype_tvar,
+		const int ensemble_id=0);
 	void SampleMean(const std::vector<int> &fileIDs,
 			OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			const int eptype, const int eptype_tvar);
+			const int epcalc, const int eptype,
+			const int eptype_tvar);
 	void SampleMeanWithWeighting(const std::vector<int> &fileIDs,
 				     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-				     const int eptype, const int eptype_tvar);
+				     const int epcalc, const int eptype,
+				     const int eptype_tvar);
 
 public:
 	aggreports(const int totalperiods, FILE **fout,

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -112,7 +112,7 @@ private:
 		      const OASIS_FLOAT tvar);
 #ifdef ORD_OUTPUT
 	template<typename T>
-	void WriteReturnPeriodOut(const std::vector<int> fileIDs,
+	void WriteReturnPeriodOut(const std::vector<int> &fileIDs,
 		size_t &nextreturnperiod_index, double &last_return_period,
 		OASIS_FLOAT &last_loss, const double current_return_period,
 		const OASIS_FLOAT current_loss, const int summary_id,
@@ -165,50 +165,48 @@ private:
 	inline parquet::StreamWriter GetParquetStreamWriter(const int fileStream);
 #endif
 	inline void DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
-		const std::vector<int> fileIDs,
 		void (aggreports::*&WriteOutput)(const std::vector<int>&,
 						 const int, const int,
 						 const int, const double,
 						 const OASIS_FLOAT));
-	void WriteExceedanceProbabilityTable(const std::vector<int> fileIDs,
+	void WriteExceedanceProbabilityTable(const std::vector<int> &fileIDs,
 					     std::map<int, lossvec> &items,
 					     const double max_retperiod,
 					     int epcalc, int eptype,
 					     int eptype_tvar, int samplesize=1,
 					     int ensemble_id=0);
-	void WriteExceedanceProbabilityTable(const std::vector<int> fileIDs,
+	void WriteExceedanceProbabilityTable(const std::vector<int> &fileIDs,
 		std::map<int, lossvec2> &items,
 		const OASIS_FLOAT cum_weight_constant, int epcalc, int eptype,
 		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
 		int samplesize=1, int ensemble_id=0);
 	inline void DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
-		const std::vector<int> fileIDs,
 		void (aggreports::*&WriteOutput)(const std::vector<int>&,
 						 const int, const int,
 						 const int, const double,
 						 const OASIS_FLOAT));
 	void WritePerSampleExceedanceProbabilityTable(
-		const std::vector<int> fileIDs,
+		const std::vector<int> &fileIDs,
 		std::map<wheatkey, lossvec> &items, int eptype, int eptype_tvar,
 		int ensemble_id=0);
 	void WritePerSampleExceedanceProbabilityTable(
-		const std::vector<int> fileIDs,
+		const std::vector<int> &fileIDs,
 		std::map<wheatkey, lossvec2> &items, int eptype,
 		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
 		int ensemble_id=0);
-	void MeanDamageRatio(const std::vector<int> fileIDs,
+	void MeanDamageRatio(const std::vector<int> &fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 			     const int eptype, const int eptype_tvar);
-	void MeanDamageRatioWithWeighting(const std::vector<int> fileIDs,
+	void MeanDamageRatioWithWeighting(const std::vector<int> &fileIDs,
 		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
 		const int eptype_tvar);
 	inline std::vector<int> GetFileIDs(const int handle, int table=EPT);
-	void FullUncertainty(const std::vector<int> fileIDs,
+	void FullUncertainty(const std::vector<int> &fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 			     const int eptype, const int eptype_tvar);
-	void FullUncertaintyWithWeighting(const std::vector<int> fileIDs,
+	void FullUncertaintyWithWeighting(const std::vector<int> &fileIDs,
 		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
 		const int eptype_tvar);
 	inline void FillWheatsheafItems(const outkey2 key,
@@ -228,10 +226,10 @@ private:
 		const std::vector<int> handles,
 		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
 		const int eptype_tvar, const int ensemble_id=0);
-	void SampleMean(const std::vector<int> fileIDs,
+	void SampleMean(const std::vector<int> &fileIDs,
 			OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 			const int eptype, const int eptype_tvar);
-	void SampleMeanWithWeighting(const std::vector<int> fileIDs,
+	void SampleMeanWithWeighting(const std::vector<int> &fileIDs,
 				     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 				     const int eptype, const int eptype_tvar);
 

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -147,9 +147,6 @@ private:
 			    const int summary_id, const int epcalc,
 			    const int eptype, const double retperiod,
 			    const OASIS_FLOAT loss);
-	void WriteNoOutput(const std::vector<int> fileIDs, const int summary_id,
-			   const int epcalc, const int eptype,
-			   const double retperiod, const OASIS_FLOAT loss);
 	void WriteTVaR(const std::vector<int> fileIDs, const int epcalc,
 		       const int eptype_tvar,
 		       const std::map<int, std::vector<TVaR>> &tail);

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -170,29 +170,26 @@ private:
 			      const std::map<wheatkey, std::vector<TVaR>> &tail);
 	inline parquet::StreamWriter GetParquetStreamWriter(const int fileStream);
 #endif
-	inline void DoSetUp(int &eptype, const int ensemble_id);
 	void WriteExceedanceProbabilityTable(const std::vector<int> &fileIDs,
 					     std::map<int, lossvec> &items,
 					     const double max_retperiod,
 					     int epcalc, int eptype,
-					     int eptype_tvar, int samplesize=1,
-					     int ensemble_id=0);
+					     int eptype_tvar, int samplesize=1);
 	void WriteExceedanceProbabilityTable(const std::vector<int> &fileIDs,
 		std::map<int, lossvec2> &items,
 		const OASIS_FLOAT cum_weight_constant, int epcalc, int eptype,
 		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
-		int samplesize=1, int ensemble_id=0);
+		int samplesize=1);
 	void WritePerSampleExceedanceProbabilityTable(
 		const std::vector<int> &fileIDs,
-		std::map<wheatkey, lossvec> &items, int eptype, int eptype_tvar,
-		int ensemble_id=0);
+		std::map<wheatkey, lossvec> &items, int eptype,
+		int eptype_tvar);
 	void WritePerSampleExceedanceProbabilityTable(
 		const std::vector<int> &fileIDs,
 		std::map<wheatkey, lossvec2> &items, int eptype,
 		int eptype_tvar,
-		std::map<int, double> &unusedperiodstoweighting,
-		int ensemble_id=0);
+		std::map<int, double> &unusedperiodstoweighting);
 	void MeanDamageRatio(const std::vector<int> &fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 			     const int epcalc, const int eptype,
@@ -220,12 +217,11 @@ private:
 					 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 					 const int epcalc, const int eptype,
 					 const int eptype_tvar,
-					 const int ensemble_id=0);
+					 int ensemble_id=0);
 	void WheatsheafAndWheatsheafMeanWithWeighting(
 		const std::vector<int> handles,
 		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int epcalc,
-		const int eptype, const int eptype_tvar,
-		const int ensemble_id=0);
+		const int eptype, const int eptype_tvar, int ensemble_id=0);
 	void SampleMean(const std::vector<int> &fileIDs,
 			OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 			const int epcalc, const int eptype,
@@ -244,17 +240,16 @@ public:
 	void SetSampleSize(const int samplesize);
 	void SetLegacyOutputFunc(int outputTable);
 	void SetORDOutputFunc(int outputTable);
-	void OutputMeanDamageRatio(const int eptype, const int eptype_tvar,
+	void OutputMeanDamageRatio(int eptype, const int eptype_tvar,
 				   OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 				   const std::vector<int> &fileIDs);
-	void OutputFullUncertainty(const int handle, const int eptype,
+	void OutputFullUncertainty(const int handle, int eptype,
 				   const int eptype_tvar,
 				   OASIS_FLOAT (OutLosses::*GetOutLoss)());
 	void OutputWheatsheafAndWheatsheafMean(const std::vector<int> &handles,
-						const int eptype,
-						const int eptype_tvar,
-						OASIS_FLOAT (OutLosses::*GetOutLoss)());
-	void OutputSampleMean(const int handle, const int eptype,
+		int eptype, const int eptype_tvar,
+		OASIS_FLOAT (OutLosses::*GetOutLoss)());
+	void OutputSampleMean(const int handle, int eptype,
 			      const int eptype_tvar,
 			      OASIS_FLOAT (OutLosses::*GetOutLoss)());
 };

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -84,6 +84,12 @@ private:
 		{ OCC_FULL_UNCERTAINTY, false }, { OCC_WHEATSHEAF, false },
 		{ OCC_SAMPLE_MEAN, false }, { OCC_WHEATSHEAF_MEAN, false }
 	};
+	void (aggreports::*WriteEPTOutput)(const std::vector<int>&, const int,
+					   const int, const int, const double,
+					   const OASIS_FLOAT) = nullptr;
+	void (aggreports::*WritePSEPTOutput)(const std::vector<int>&, const int,
+					     const int, const int, const double,
+					     const OASIS_FLOAT) = nullptr;
 #ifdef ORD_OUTPUT
 	bool os_ept_exists_ = false;
 	parquet::StreamWriter os_ept_;
@@ -164,11 +170,7 @@ private:
 			      const std::map<wheatkey, std::vector<TVaR>> &tail);
 	inline parquet::StreamWriter GetParquetStreamWriter(const int fileStream);
 #endif
-	inline void DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
-		void (aggreports::*&WriteOutput)(const std::vector<int>&,
-						 const int, const int,
-						 const int, const double,
-						 const OASIS_FLOAT));
+	inline void DoSetUp(int &eptype, int &epcalc, const int ensemble_id);
 	void WriteExceedanceProbabilityTable(const std::vector<int> &fileIDs,
 					     std::map<int, lossvec> &items,
 					     const double max_retperiod,
@@ -181,11 +183,7 @@ private:
 		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
 		int samplesize=1, int ensemble_id=0);
-	inline void DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
-		void (aggreports::*&WriteOutput)(const std::vector<int>&,
-						 const int, const int,
-						 const int, const double,
-						 const OASIS_FLOAT));
+	inline void DoSetUpWheatsheaf(int &eptype, const int ensemble_id);
 	void WritePerSampleExceedanceProbabilityTable(
 		const std::vector<int> &fileIDs,
 		std::map<wheatkey, lossvec> &items, int eptype, int eptype_tvar,
@@ -240,6 +238,8 @@ public:
 	void SetInputData(const std::set<int> &summaryids,
 			  std::vector<std::map<outkey2, OutLosses>> &out_loss);
 	void SetSampleSize(const int samplesize);
+	void SetLegacyOutputFunc(int outputTable);
+	void SetORDOutputFunc(int outputTable);
 	void OutputMeanDamageRatio(const int eptype, const int eptype_tvar,
 				   OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 				   const std::vector<int> &fileIDs);

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -62,11 +62,11 @@ struct line_points{
 class aggreports {
 private:
 	const int totalperiods_;
-	const std::set<int> summaryids_;
-	std::vector<std::map<outkey2, OutLosses>> &out_loss_;
+	std::set<int> summaryids_;
+	std::vector<std::map<outkey2, OutLosses>> *out_loss_;
 	FILE **fout_;
 	bool useReturnPeriodFile_;
-	const int samplesize_;
+	int samplesize_;
 	const bool *outputFlags_;
 	const bool ordFlag_;
 	const std::string *parquetFileNames_;
@@ -234,10 +234,15 @@ private:
 				     const int eptype, const int eptype_tvar);
 
 public:
-	aggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool *outputFlags, const bool ordFlag, const std::string *parquetFileNames);
+	aggreports(const int totalperiods, FILE **fout,
+		   const bool useReturnPeriodFile, const bool *outputFlags,
+		   const bool ordFlag, const std::string *parquetFileNames);
+	void SetInputData(const std::set<int> &summaryids,
+			  std::vector<std::map<outkey2, OutLosses>> &out_loss);
+	void SetSampleSize(const int samplesize);
 	void OutputMeanDamageRatio(const int eptype, const int eptype_tvar,
 				   OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-				   std::vector<int> &fileIDs);
+				   const std::vector<int> &fileIDs);
 	void OutputFullUncertainty(const int handle, const int eptype,
 				   const int eptype_tvar,
 				   OASIS_FLOAT (OutLosses::*GetOutLoss)());

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -64,20 +64,20 @@ private:
 	const int totalperiods_;
 	const std::set<int> summaryids_;
 	std::vector<std::map<outkey2, OutLosses>> &out_loss_;
-	const bool *outputFlags_;
 	FILE **fout_;
+	bool useReturnPeriodFile_;
+	const int samplesize_;
+	const bool *outputFlags_;
+	const bool ordFlag_;
 	const std::string *parquetFileNames_;
 	bool eptHeader_ = true;
 	bool pseptHeader_ = true;
 	std::map<int, bool> wheatSheaf_ = {
 		{ 0, true }, { OEP, false }, { AEP, false }
 	};   // key 0 for fail safe
-	bool useReturnPeriodFile_;
-	const int samplesize_;
 	std::vector<int> returnperiods_;
 	std::map <int, double> periodstoweighting_;
 	std::map<int, std::vector<int>> ensembletosidx_;
-	const bool ordFlag_;
 	std::map<int, bool> fileHeaders_ = {
 		{ AGG_FULL_UNCERTAINTY, false }, { AGG_WHEATSHEAF, false },
 		{ AGG_SAMPLE_MEAN, false }, { AGG_WHEATSHEAF_MEAN, false },

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -78,7 +78,6 @@ private:
 	std::vector<int> returnperiods_;
 	std::map <int, double> periodstoweighting_;
 	std::map<int, std::vector<int>> ensembletosidx_;
-	const bool skipheader_;
 	const bool ordFlag_;
 	std::map<int, bool> fileHeaders_ = {
 		{ AGG_FULL_UNCERTAINTY, false }, { AGG_WHEATSHEAF, false },
@@ -236,7 +235,7 @@ private:
 				     const int eptype);
 
 public:
-	aggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool skipheader, const bool *outputFlags, const bool ordFlag, const std::string *parquetFileNames);
+	aggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool *outputFlags, const bool ordFlag, const std::string *parquetFileNames);
 	void OutputAggMeanDamageRatio();
 	void OutputOccMeanDamageRatio();
 	void OutputAggFullUncertainty();

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -118,39 +118,39 @@ private:
 		const OASIS_FLOAT current_loss, const int summary_id,
 		const int eptype, const int epcalc, const double max_retperiod,
 		int counter, OASIS_FLOAT tvar, T &tail,
-		void (aggreports::*WriteOutput)(const std::vector<int>,
+		void (aggreports::*WriteOutput)(const std::vector<int>&,
 						const int, const int, const int,
 						const double,
 						const OASIS_FLOAT),
 		parquet::StreamWriter& os);
 #else
 	template<typename T>
-	void WriteReturnPeriodOut(const std::vector<int> fileIDs,
+	void WriteReturnPeriodOut(const std::vector<int> &fileIDs,
 		size_t &nextreturnperiod_index, double &last_return_period,
 		OASIS_FLOAT &last_loss, const double current_return_period,
 		const OASIS_FLOAT current_loss, const int summary_id,
 		const int eptype, const int epcalc, const double max_retperiod,
 		int counter, OASIS_FLOAT tvar, T &tail,
-		void (aggreports::*WriteOutput)(const std::vector<int>,
+		void (aggreports::*WriteOutput)(const std::vector<int>&,
 						const int, const int, const int,
 						const double,
 						const OASIS_FLOAT));
 #endif
-	inline void OutputRows(const std::vector<int> fileIDs,
+	inline void OutputRows(const std::vector<int> &fileIDs,
 			       const char * buffer, int strLen);
-	void WriteLegacyOutput(const std::vector<int> fileIDs,
+	void WriteLegacyOutput(const std::vector<int> &fileIDs,
 			       const int summary_id, const int type,
 			       const int ensemble_id,
 			       const double retperiod,
 			       const OASIS_FLOAT loss);
-	void WriteORDOutput(const std::vector<int> fileIDs,
+	void WriteORDOutput(const std::vector<int> &fileIDs,
 			    const int summary_id, const int epcalc,
 			    const int eptype, const double retperiod,
 			    const OASIS_FLOAT loss);
-	void WriteTVaR(const std::vector<int> fileIDs, const int epcalc,
+	void WriteTVaR(const std::vector<int> &fileIDs, const int epcalc,
 		       const int eptype_tvar,
 		       const std::map<int, std::vector<TVaR>> &tail);
-	void WriteTVaR(const std::vector<int> fileIDs, const int eptype_tvar,
+	void WriteTVaR(const std::vector<int> &fileIDs, const int eptype_tvar,
 		       const std::map<wheatkey, std::vector<TVaR>> &tail);
 #ifdef ORD_OUTPUT
 	inline void WriteParquetOutput(parquet::StreamWriter& os,
@@ -166,7 +166,7 @@ private:
 #endif
 	inline void DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
 		const std::vector<int> fileIDs,
-		void (aggreports::*&WriteOutput)(const std::vector<int>,
+		void (aggreports::*&WriteOutput)(const std::vector<int>&,
 						 const int, const int,
 						 const int, const double,
 						 const OASIS_FLOAT));
@@ -184,7 +184,7 @@ private:
 		int samplesize=1, int ensemble_id=0);
 	inline void DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
 		const std::vector<int> fileIDs,
-		void (aggreports::*&WriteOutput)(const std::vector<int>,
+		void (aggreports::*&WriteOutput)(const std::vector<int>&,
 						 const int, const int,
 						 const int, const double,
 						 const OASIS_FLOAT));

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -167,8 +167,8 @@ private:
 			      const std::map<wheatkey, std::vector<TVaR>> &tail);
 	inline parquet::StreamWriter GetParquetStreamWriter(const int fileStream);
 #endif
-	inline void DoSetUp(int &eptype, int &eptype_tvar, int &epcalc,
-		const int ensemble_id, const std::vector<int> fileIDs,
+	inline void DoSetUp(int &eptype, int &epcalc, const int ensemble_id,
+		const std::vector<int> fileIDs,
 		void (aggreports::*&WriteOutput)(const std::vector<int>,
 						 const int, const int,
 						 const int, const double,
@@ -177,39 +177,43 @@ private:
 					     std::map<int, lossvec> &items,
 					     const double max_retperiod,
 					     int epcalc, int eptype,
-					     int samplesize=1,
+					     int eptype_tvar, int samplesize=1,
 					     int ensemble_id=0);
 	void WriteExceedanceProbabilityTable(const std::vector<int> fileIDs,
 		std::map<int, lossvec2> &items,
 		const OASIS_FLOAT cum_weight_constant, int epcalc, int eptype,
+		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
 		int samplesize=1, int ensemble_id=0);
-	inline void DoSetUpWheatsheaf(int &eptype, int &eptype_tvar,
-		const int ensemble_id, const std::vector<int> fileIDs,
+	inline void DoSetUpWheatsheaf(int &eptype, const int ensemble_id,
+		const std::vector<int> fileIDs,
 		void (aggreports::*&WriteOutput)(const std::vector<int>,
 						 const int, const int,
 						 const int, const double,
 						 const OASIS_FLOAT));
 	void WritePerSampleExceedanceProbabilityTable(
 		const std::vector<int> fileIDs,
-		std::map<wheatkey, lossvec> &items, int eptype,
+		std::map<wheatkey, lossvec> &items, int eptype, int eptype_tvar,
 		int ensemble_id=0);
 	void WritePerSampleExceedanceProbabilityTable(
 		const std::vector<int> fileIDs,
 		std::map<wheatkey, lossvec2> &items, int eptype,
+		int eptype_tvar,
 		std::map<int, double> &unusedperiodstoweighting,
 		int ensemble_id=0);
 	void MeanDamageRatio(const std::vector<int> fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			     const int eptype);
+			     const int eptype, const int eptype_tvar);
 	void MeanDamageRatioWithWeighting(const std::vector<int> fileIDs,
-		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype);
+		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
+		const int eptype_tvar);
 	inline std::vector<int> GetFileIDs(const int handle, int table=EPT);
 	void FullUncertainty(const std::vector<int> fileIDs,
 			     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			     const int eptype);
+			     const int eptype, const int eptype_tvar);
 	void FullUncertaintyWithWeighting(const std::vector<int> fileIDs,
-		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype);
+		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
+		const int eptype_tvar);
 	inline void FillWheatsheafItems(const outkey2 key,
 					std::map<wheatkey, lossvec> &items,
 					const OASIS_FLOAT loss);
@@ -221,17 +225,18 @@ private:
 	void WheatsheafAndWheatsheafMean(const std::vector<int> handles,
 					 OASIS_FLOAT (OutLosses::*GetOutLoss)(),
 					 const int eptype,
+					 const int eptype_tvar,
 					 const int ensemble_id=0);
 	void WheatsheafAndWheatsheafMeanWithWeighting(
 		const std::vector<int> handles,
 		OASIS_FLOAT (OutLosses::*GetOutLoss)(), const int eptype,
-		const int ensemble_id=0);
+		const int eptype_tvar, const int ensemble_id=0);
 	void SampleMean(const std::vector<int> fileIDs,
 			OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-			const int eptype);
+			const int eptype, const int eptype_tvar);
 	void SampleMeanWithWeighting(const std::vector<int> fileIDs,
 				     OASIS_FLOAT (OutLosses::*GetOutLoss)(),
-				     const int eptype);
+				     const int eptype, const int eptype_tvar);
 
 public:
 	aggreports(const int totalperiods, const std::set<int> &summaryids, std::vector<std::map<outkey2, OutLosses>> &out_loss, FILE **fout, const bool useReturnPeriodFile, const int samplesize, const bool *outputFlags, const bool ordFlag, const std::string *parquetFileNames);

--- a/src/leccalc/aggreports.h
+++ b/src/leccalc/aggreports.h
@@ -248,13 +248,5 @@ public:
 	void OutputSampleMean(const int handle, const int eptype,
 			      const int eptype_tvar,
 			      OASIS_FLOAT (OutLosses::*GetOutLoss)());
-//	void OutputAggMeanDamageRatio();
-//	void OutputOccMeanDamageRatio();
-//	void OutputAggFullUncertainty();
-//	void OutputOccFullUncertainty();
-//	void OutputAggWheatsheafAndWheatsheafMean();
-//	void OutputOccWheatsheafAndWheatsheafMean();
-//	void OutputAggSampleMean();
-//	void OutputOccSampleMean();
 };
 #endif // AGGREPORTS_H_

--- a/src/leccalc/leccalc.cpp
+++ b/src/leccalc/leccalc.cpp
@@ -280,7 +280,8 @@ namespace leccalc {
 				     const bool *outputFlags,
 				     const bool skipheader,
 				     std::vector<int> &fileIDs_occ,
-				     std::vector<int> &fileIDs_agg)
+				     std::vector<int> &fileIDs_agg,
+				     aggreports &agg)
 	{
 		bool hasEPT = false;
 
@@ -296,6 +297,29 @@ namespace leccalc {
 						       OCC_WHEATSHEAF_MEAN };
 		getfileids(fout, handles_occ, ordFlag, outputFlags,
 			   fileIDs_occ, hasEPT);
+
+		const std::vector<int> handles_psept = { AGG_WHEATSHEAF,
+							 OCC_WHEATSHEAF };
+		std::vector<int> fileIDs_psept;
+		for (auto it = handles_psept.begin(); it != handles_psept.end();
+		     ++it) {
+			if (outputFlags[*it]) fileIDs_psept.push_back(*it);
+		}
+		if (fileIDs_psept.size() > 0 && ordFlag) {
+			fileIDs_psept.clear();
+			if (fout[PSEPT] != nullptr)
+				fileIDs_psept.push_back(PSEPT);
+		}
+
+		// Set write csv functions
+		if ((fileIDs_occ.size() + fileIDs_agg.size()) > 0) {
+			if (ordFlag) agg.SetORDOutputFunc(EPT);
+			else agg.SetLegacyOutputFunc(EPT);
+		}
+		if (fileIDs_psept.size() > 0) {
+			if (ordFlag) agg.SetORDOutputFunc(PSEPT);
+			else agg.SetLegacyOutputFunc(PSEPT);
+		}
 
 		if (skipheader) return hasEPT;   // No header
 
@@ -334,18 +358,6 @@ namespace leccalc {
 
 		// Print headers for Per Sample Exceedance Probability Table
 		// (i.e. Wheatsheaf)
-		const std::vector<int> handles_psept = { AGG_WHEATSHEAF,
-							 OCC_WHEATSHEAF };
-		std::vector<int> fileIDs_psept;
-		for (auto it = handles_psept.begin(); it != handles_psept.end();
-		     ++it) {
-			if (outputFlags[*it]) fileIDs_psept.push_back(*it);
-		}
-		if (fileIDs_psept.size() > 0 && ordFlag) {
-			fileIDs_psept.clear();
-			if (fout[PSEPT] != nullptr)
-				fileIDs_psept.push_back(PSEPT);
-		}
 		for (auto it = fileIDs_psept.begin(); it != fileIDs_psept.end();
 		     ++it) {
 			fprintf(fout[*it], "%s\n", fileHeader_psept.c_str());
@@ -405,7 +417,7 @@ namespace leccalc {
 		std::vector<int> fileIDs_occ, fileIDs_agg;
 		bool hasEPT = setupoutputfiles(fout, ordFlag, outputFlags,
 					       skipheader, fileIDs_occ,
-					       fileIDs_agg);
+					       fileIDs_agg, agg);
 
 		std::vector<std::string> files;
 		std::vector<FILE*> fileHandles;

--- a/src/leccalc/leccalc.cpp
+++ b/src/leccalc/leccalc.cpp
@@ -124,8 +124,8 @@ namespace leccalc {
 		}
 
 		int date_opts = 0;
-		size_t i = fread(&date_opts, sizeof(date_opts), 1, fin);
-		i = fread(&totalperiods, sizeof(totalperiods), 1, fin);
+		fread(&date_opts, sizeof(date_opts), 1, fin);
+		fread(&totalperiods, sizeof(totalperiods), 1, fin);
 		int granular_date = date_opts >> 1;
 		if (granular_date) {
 			occurrence_granular occ;
@@ -263,6 +263,10 @@ namespace leccalc {
 				fileIDs.push_back(EPT);
 		}
 	}
+
+
+	
+
 
 	inline bool setupoutputfiles(FILE **fout, const bool ordFlag,
 				     const bool *outputFlags,

--- a/src/leccalc/leccalc.h
+++ b/src/leccalc/leccalc.h
@@ -44,6 +44,7 @@ Author: Ben Matharu  email: ben.matharu@oasislmf.org
 
 enum { AGG_FULL_UNCERTAINTY = 0, AGG_WHEATSHEAF, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF_MEAN, OCC_FULL_UNCERTAINTY, OCC_WHEATSHEAF, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF_MEAN };
 enum { EPT = 0, PSEPT };
+enum { OEP = 1, OEPTVAR, AEP, AEPTVAR };
 
 struct OutLosses {
 	OutLosses() {


### PR DESCRIPTION
<!--start_release_notes-->
### Fix missing header in Wheatsheaf output in leccalc and ordleccalc
The logic for determining whether headers are written out has been simplified and moved outside of the `aggreports` class, which has aided the readability of the code. Additionally, this has fixed the missing header issue in the Wheatsheaf output, which has been witnessed when the lowest summary ID yields no output (i.e. when all the samples are zero loss).

### Refactor aggreports class
The `aggreports` class has been refactored and methods have been simplified in an attempt to optimise the code and make it more readable. The determination of a number of variables have been moved to parent functions, including `EPCalc` and `EPType`. The initialisation of the `aggreports` class has been brought outside any loops, reducing overhead, as has the determination of legacy or ORD output. Other minor changes include passing vectors by reference and replacing a function call with a conditional.
<!--end_release_notes-->
