### PR TITLE
Bring split TIV calculation in line with gulpy

### DIFF
--- a/src/gulcalc/gulcalc.cpp
+++ b/src/gulcalc/gulcalc.cpp
@@ -362,7 +362,11 @@ void gulcalc::writemode1output(const int event_id, const OASIS_FLOAT tiv,
 	// If so, split TIV in proportion to losses
 	for (size_t i = 0; i < gilv.size(); i++) {
 
-		split_tiv(gilv[i], tiv);
+		if ((i != num_idx_ + std_dev_idx) ||
+		    (i != num_idx_ + chance_of_loss_idx)) {
+			split_tiv(gilv[i], tiv);
+		}
+
 		auto iter = gilv[i].begin();
 		while (iter != gilv[i].end()) {
 


### PR DESCRIPTION
<!--start_release_notes-->
### Bring split TIV calculation in line with gulpy
With `gulcalc` allocation rule greater than 0, if the sum of losses per sample exceed the TIV, the TIV is split in proportion to the losses. There is no need to do this for the standard deviation (`sidx = -2`) nor for the chance of loss (`sidx = -4`). Therefore, the calculation on these fields has been dropped to bring it in line with that which is currently conducted in `gulpy`.
<!--end_release_notes-->
