### PR TITLE
Add check for pkg-config in autotools build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,15 @@ AX_CXX_COMPILE_STDCXX_11
 AX_CHECK_ZLIB()
 # Checks for libraries.
 
+# Check for pkg-config
+AC_MSG_CHECKING([for pkg-config])
+PKGCONFIG=no
+pkg-config --version > /dev/null 2>&1 && PKGCONFIG=yes
+AC_MSG_RESULT([$PKGCONFIG])
+AS_IF([test "x$PKGCONFIG" = "xno"],
+      [AC_MSG_ERROR([cannot find pkg-config. Please install pkg-config and run ./configure again.])
+])
+
 # Check for arrow and parquet libraries
 # Provide option to disable search for parquet libraries for debugging
 AC_ARG_ENABLE([parquet],


### PR DESCRIPTION
<!--start_release_notes-->
### Add check for pkg-config in build system
The option to output results in parquet format has been available since v3.8.0. To facilitate the linking of the Arrow Parquet libraries necessary for this, autotools uses `pkg-config`, which has become a prerequisite. Should this package be missing, a misleading error message is displayed, which can be interpreted to point towards the fault lying with the installation of the Arrow Parquet libraries.

A check for `pkg-config` has been introduced to the autotools build system. The new error message is more helpful:

```
checking for pkg-config... no
configure: error: cannot find pkg-config. Please install pkg-config and run ./configure again.
```
<!--end_release_notes-->