### PR TITLE
Remove condition causing empty leccalc/ordleccalc output files when using period weights and user-defined return periods

### DIFF
--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -603,7 +603,6 @@ void aggreports::WriteExceedanceProbabilityTable(
 
       if (lp.period_weighting) {
 	double retperiod = 1 / cumulative_weighting;
-	if (retperiod < 1)
 
 	if (!largest_loss) {
 	  max_retperiod = retperiod + 0.0001;   // Add for floating point errors


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Remove condition causing empty leccalc/ordleccalc output files when using period weights and user-defined return periods
A leftover condition statement resulted in miscalculation of the maximum return period. The maximum return period is used to determine losses corresponding to user-requested return periods, and as the maximum return period was set at 0, all requested return periods lay beyond this maximum and were not calculated. Removing this conditional has solved the issue.
<!--end_release_notes-->
