### PR TITLE
Fix standard deviation for type 2 entries in pltcalc output

### DIFF
--- a/src/pltcalc/pltcalc.cpp
+++ b/src/pltcalc/pltcalc.cpp
@@ -544,10 +544,14 @@ namespace pltcalc {
 			}
 			if (hasrec) {
 				o.mean = loss_sum / samplesize_;
-				OASIS_FLOAT sd = (squared_loss_sum - ((loss_sum * loss_sum) / samplesize_)) / (samplesize_ - 1);
-				OASIS_FLOAT x = sd / squared_loss_sum;
-				if (x < 0.0000001) sd = 0;   // fix OASIS_FLOATing point precision problems caused by using large numbers
-				o.standard_deviation = sqrt(sd);
+				if (samplesize_ != 1) {
+					OASIS_FLOAT sd = (squared_loss_sum - ((loss_sum * loss_sum) / samplesize_)) / (samplesize_ - 1);
+					OASIS_FLOAT x = sd / squared_loss_sum;
+					if (x < 0.0000001) sd = 0;   // fix OASIS_FLOATing point precision problems caused by using large numbers
+					o.standard_deviation = sqrt(sd);
+				} else {
+					o.standard_deviation = 0;
+				}
 				if (o.mean > 0 || o.standard_deviation > 0) {
 					OutputData(o, 2, outFile);
 				}

--- a/src/pltcalc/pltcalc.cpp
+++ b/src/pltcalc/pltcalc.cpp
@@ -495,7 +495,7 @@ namespace pltcalc {
 		o.mean = mean_val;
 		o.standard_deviation = 0;
 		for (auto p : vp) {
-			if (o.mean > 0 || o.standard_deviation > 0) {
+			if (o.mean > 0) {
 				o.period_no = p.period_no;
 				o.occ_date_id = p.occ_date_id;
 				OutputData(o, 1, outFile);


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix standard deviation for type 2 entries in pltcalc output
When the sample size is 1, the mean is the loss value of that sample and the standard deviation is 0. The standard deviation in the `pltcalc` output has been set to 0 in this case. This affects the legacy `pltcalc` output and the ORD Moment Period Loss Table (MPLT).
<!--end_release_notes-->
