### PR TITLE
Allow number of affected risks to be processed by summarycalctocsv

### DIFF
--- a/src/aalcalc/aalcalc.cpp
+++ b/src/aalcalc/aalcalc.cpp
@@ -706,7 +706,7 @@ void aalcalc::doit(const std::string& subfolder)
 					sampleslevelRec sr;
 					i = fread(&sr, sizeof(sr), 1, summary_fin);
 					if (i == 0 || sr.sidx == 0) break;
-					if (sr.sidx == chance_of_loss_idx || sr.sidx == max_loss_idx) continue;
+					if (sr.sidx == number_of_affected_risk_idx || sr.sidx == max_loss_idx) continue;
 					vrec.push_back(sr);
 				}
 				do_calc_by_period(sh, vrec);

--- a/src/aalcalcmeanonly/aalcalcmeanonly.cpp
+++ b/src/aalcalcmeanonly/aalcalcmeanonly.cpp
@@ -104,7 +104,7 @@ namespace aalcalcmeanonly {
         sampleslevelRec sr;
         i = fread(&sr, sizeof(sr), 1, fin);
 
-        if (sr.sidx == chance_of_loss_idx || sr.sidx == max_loss_idx) continue;
+        if (sr.sidx == number_of_affected_risk_idx || sr.sidx == max_loss_idx) continue;
         if (i == 0 || sr.sidx == 0) break;
 
         means_[sh.summary_id][sr.sidx != -1] += (sr.loss * weight / (1 + (sampleSize_ - 1) * (sr.sidx != -1)));

--- a/src/gulcalc/gulcalc.cpp
+++ b/src/gulcalc/gulcalc.cpp
@@ -363,7 +363,7 @@ void gulcalc::writemode1output(const int event_id, const OASIS_FLOAT tiv,
 	for (size_t i = 0; i < gilv.size(); i++) {
 
 		if ((i != num_idx_ + std_dev_idx) ||
-		    (i != num_idx_ + chance_of_loss_idx)) {
+		    (i != num_idx_ + number_of_affected_risk_idx)) {
 			split_tiv(gilv[i], tiv);
 		}
 

--- a/src/include/oasis.h
+++ b/src/include/oasis.h
@@ -85,7 +85,7 @@ typedef unsigned int AREAPERIL_INT;
 const int mean_idx = -1;
 const int std_dev_idx = -2;
 const int tiv_idx = -3;
-const int chance_of_loss_idx = -4;   // Reserved
+const int number_of_affected_risk_idx = -4;
 const int max_loss_idx = -5;
 
 // Stream types

--- a/src/leccalc/leccalc.cpp
+++ b/src/leccalc/leccalc.cpp
@@ -234,7 +234,7 @@ namespace leccalc {
 					break;
 				}
 
-				if (sr.sidx == chance_of_loss_idx || sr.sidx == max_loss_idx) {
+				if (sr.sidx == number_of_affected_risk_idx || sr.sidx == max_loss_idx) {
 					continue;
 				}
 
@@ -553,7 +553,7 @@ namespace leccalc {
 						sampleslevelRec sr;
 						i = fread(&sr, sizeof(sr), 1, summary_fin);
 						if (i != 1 || sr.sidx == 0) break;
-						if (sr.sidx == chance_of_loss_idx || sr.sidx == max_loss_idx) continue;
+						if (sr.sidx == number_of_affected_risk_idx || sr.sidx == max_loss_idx) continue;
 						dolecoutputaggsummary(sh.summary_id, sr.sidx, sr.loss, iter->second, out_loss);
 					}
 				}

--- a/src/pltcalc/pltcalc.cpp
+++ b/src/pltcalc/pltcalc.cpp
@@ -578,7 +578,7 @@ namespace pltcalc {
 				OASIS_FLOAT impacted_exposure = 0;
 				sampleslevelRec sr;
 				i = fread(&sr, sizeof(sr), 1, stdin);
-				if (sr.sidx == chance_of_loss_idx) continue;   // Ignore chance of loss
+				if (sr.sidx == number_of_affected_risk_idx) continue;
 				if (i == 0 || sr.sidx == 0) {
 					dopltcalc(sh, vrec, OutputData, outFile,
 						  m_occ, vp,

--- a/src/summarycalc/summarycalc.cpp
+++ b/src/summarycalc/summarycalc.cpp
@@ -311,7 +311,7 @@ void summarycalc::outputsummaryset(int sample_size, int summary_set, int event_i
 			fwrite(&sh, sizeof(sh), 1, fout[summary_set]);
 			offset_[summary_set] += sizeof(sh);
 			for (int j = first_idx_; j < sample_size + num_idx_ + 1; j++) {
-				if (j != num_idx_ && j != chance_of_loss_idx + num_idx_) {   // sidx = 0 AND sidx = chance_of_loss_idx
+				if (j != num_idx_ && j != number_of_affected_risk_idx + num_idx_) {   // sidx = 0 AND sidx = number_of_affected_risk_idx
 					sampleslevelRec s;
 					s.sidx = j - num_idx_;
 					if (s.sidx == tiv_idx || s.sidx == std_dev_idx) {
@@ -610,7 +610,7 @@ void summarycalc::dosummaryprocessing(int samplesize)
 			i = (int)fread(&sr, sizeof(sr), 1, stdin);
 			if (i == 0) break;
 			if (sr.sidx == 0) break;
-			if (sr.sidx == chance_of_loss_idx) continue;   // Ignore chance of loss
+			if (sr.sidx == number_of_affected_risk_idx) continue;
 			if (sr.sidx == tiv_idx) {
 				expure_val = sr.loss;
 			} else if (sr.sidx == max_loss_idx) {

--- a/src/summarycalctocsv/summarycalctocsv.cpp
+++ b/src/summarycalctocsv/summarycalctocsv.cpp
@@ -103,7 +103,6 @@ void doitz(bool skipheader, bool fullprecision, bool show_exposure_value,
 				i = fread(&sr, sizeof(sr), 1, stdin);
 				if (i == 0) break;
 				if (sr.sidx == 0) break;
-				if (sr.sidx == chance_of_loss_idx) continue;   // Ignore chance of loss
 				if (!all_idx && sr.sidx == max_loss_idx) {   // Only output MaxLoss if flag set
 					continue;
 				}
@@ -205,7 +204,6 @@ void doit(bool skipheader, bool fullprecision,bool show_exposure_value,
 				i = fread(&sr, sizeof(sr), 1, stdin);
 				if (i == 0) break;	
 				if (sr.sidx == 0) break;
-				if (sr.sidx == chance_of_loss_idx) continue;   // Ignore chance of loss
 				if (!all_idx && sr.sidx == max_loss_idx) {   // Only output MaxLoss if flag set
 					continue;
 				}


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Allow number of affected risks to be processed by summarycalctocsv
Sample index (`sidx`) -4 has been reassigned to represent the number of affected risks. Therefore, filters on `sidx = -4` have been removed in `summarycalctocsv`, allowing for the number of affected risks to be included in the output csv file.
<!--end_release_notes-->
