### PR TITLE
Remove default range for event IDs in footprinttocsv

### DIFF
--- a/src/footprinttocsv/footprinttocsv.cpp
+++ b/src/footprinttocsv/footprinttocsv.cpp
@@ -109,6 +109,7 @@ namespace footprinttocsv {
 	void doitz(bool skipheader, int from_event, int to_event, const char * binFileName="footprint.bin.z", const char * idxFileName="footprint.idx.z")
 	{
 		if (skipheader == false)  printf("event_id, areaperil_id, intensity_bin_id, probability\n");
+		bool no_event_range = ( (from_event == to_event) && (from_event == 0) );
 		FILE *finx = fopen(binFileName, "rb");
 		FILE *finy = fopen(idxFileName, "rb");
 		EventIndex current_idx;
@@ -143,7 +144,8 @@ namespace footprinttocsv {
 				long long pos = fltell(finx);
 				compressed_length = pos - current_idx.offset;
 			}
-			if (current_idx.event_id >= from_event && current_idx.event_id <= to_event) {
+			if ((no_event_range) ||
+			    (current_idx.event_id >= from_event && current_idx.event_id <= to_event)) {
 				flseek(finx, current_idx.offset, SEEK_SET);
 				printrowsz(current_idx.event_id, finx, compressed_length, uncompressed_length);
 			}
@@ -161,6 +163,7 @@ namespace footprinttocsv {
 	void doit(bool skipheader, int from_event, int to_event, const char * binFileName="footprint.bin", const char * idxFileName="footprint.idx")
 	{
 		if (skipheader == false)  printf("event_id, areaperil_id, intensity_bin_id, probability\n");
+		bool no_event_range = ( (from_event == to_event) && (from_event == 0) );
 		FILE *finx = fopen(binFileName, "rb");
 		FILE *finy = fopen(idxFileName, "rb");
 
@@ -172,7 +175,8 @@ namespace footprinttocsv {
 		}
 		size_t i = fread(&idx, sizeof(idx), 1, finy);
 		while (i != 0) {
-			if (idx.event_id >= from_event && idx.event_id <= to_event) {
+			if ((no_event_range) ||
+			    (idx.event_id >= from_event && idx.event_id <= to_event)) {
 				flseek(finx, idx.offset, SEEK_SET);
 				printrows(idx.event_id, finx, idx.size);
 			}

--- a/src/footprinttocsv/main.cpp
+++ b/src/footprinttocsv/main.cpp
@@ -86,8 +86,8 @@ int main(int argc, char* argv[])
 	int opt;
 	bool skipheader = false;
 	bool zip = false;
-	int from_event = 1;
-	int to_event = 999999999;
+	int from_event = 0;   // No minimum event ID by default
+	int to_event = 0;   // No maximum event ID by default
 	char *binFileName = 0;
 	bool binFileGiven = false;
 	char *idxFileName = 0;
@@ -113,6 +113,7 @@ int main(int argc, char* argv[])
 					from_event = atoi(result[0].c_str());
 					to_event = atoi(result[1].c_str());
 				}
+				// Must set finite limits if setting range from command line
 				if (from_event == 0) {
 					fprintf(stderr, "FATAL: Invalid from event_id\n");
 					exit(EXIT_FAILURE);


### PR DESCRIPTION
<!--start_release_notes-->
### Remove default range for event IDs in footprinttocsv
With the `-e` flag, a user is able to specify a range of event IDs to output when converting footprint binary files to csv using `footprinttocsv`. Should a range not have been entered, a default was used. This default had minimum and maximum limits of 1 and 999,999,999 respectively. As event IDs that are greater than this maximum limit should be valid, the range has been removed. Therefore, if a range is not requested by the user, all event IDs are now converted from binary to csv and sent to the output.
<!--end_release_notes-->