### PR TITLE
fix: allow md5sum check to include `/usr/local/bin`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,13 +10,13 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_LANG([C])
 AC_LANG([C++])
 
-AC_MSG_CHECKING([Check for /usr/bin/md5sum ])
-if [[ -f /usr/bin/md5sum ]];
+AC_MSG_CHECKING([Check for /usr/bin/md5sum or /usr/local/bin/md5sum ])
+if [[ -f /usr/bin/md5sum ]] || [[ -f /usr/local/bin/md5sum ]];
 then
 	AC_MSG_RESULT([yes])
 else
 	AC_MSG_RESULT([no])
-	AC_MSG_NOTICE([ /usr/bin/md5sum not found - cannot do make check])
+	AC_MSG_NOTICE([ /usr/bin/md5sum and /usr/local/bin/md5sum not found - cannot do make check])
 fi
 
 AC_ARG_ENABLE(debug,


### PR DESCRIPTION
@sambles A small tweak to `configure.ac` to add `/usr/local/bin/md5sum` in the `md5sum` check - this check would pass if the user had installed it via `apt` on Linux or `brew` on Macs. For Macs, a Brew install is insufficient as a symlink would still need to be created in `/usr/local/bin`, but this is common practice.

This is the `./configure` check before the change:
```bash
checking Check for /usr/bin/md5sum ... no
...
```
This is the same line after the change:
```bash
checking Check for /usr/bin/md5sum or /usr/local/bin/md5sum ... yes
```

Whether this makes any difference to the checksums in `make test` I'm not sure, but it is a friendlier configuration.