### PR TITLE
Fix variable shadowing bug in leccalc aggreports

### DIFF
--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -1311,7 +1311,7 @@ void aggreports::WheatsheafAndWheatsheafMeanWithWeighting(
 
   std::vector<int> fileIDs;
   if (outputFlags_[handles[WHEATSHEAF]] == true) {
-    std::vector<int> fileIDs = GetFileIDs(handles[WHEATSHEAF], PSEPT);
+    fileIDs = GetFileIDs(handles[WHEATSHEAF], PSEPT);
   }
   WritePerSampleExceedanceProbabilityTable(fileIDs, items, eptype, eptype_tvar,
 					   unusedperiodstoweighting, temp_map);


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix variable shadowing bug in leccalc aggreports

- Fixed a variable shadowing bug in `leccalc/aggreports.cpp` where `fileIDs` was redeclared inside an `if` block, shadowing the outer variable and leaving it empty when passed to `WritePerSampleExceedanceProbabilityTable`

<!--end_release_notes-->
#405