### PR TITLE
Fix summary_id set to -1 for wheatsheaf mean outputs

### DIFF
--- a/src/leccalc/aggreports.cpp
+++ b/src/leccalc/aggreports.cpp
@@ -953,6 +953,7 @@ void aggreports::WriteWheatsheafMean(const std::vector<int> &fileIDs,
     int i = 1;
 
     for (auto mc : rmc) {
+      if (mc.count == 0) continue;   // Skip unpopulated entries
 
       if (WriteEPTOutput != nullptr) {
 	(this->*WriteEPTOutput)(fileIDs, s.first, epcalc, eptype, mc.retperiod,

--- a/src/leccalc/leccalc.cpp
+++ b/src/leccalc/leccalc.cpp
@@ -558,10 +558,12 @@ namespace leccalc {
 					}
 				}
 			}
-			summaryids.clear();
-			summaryids.insert(last_summary_id);
-			outputaggreports(agg, summaryids, out_loss, samplesize,
-					 fileIDs_occ, fileIDs_agg, hasEPT);
+			if (last_summary_id != -1) {
+				summaryids.clear();
+				summaryids.insert(last_summary_id);
+				outputaggreports(agg, summaryids, out_loss, samplesize,
+						 fileIDs_occ, fileIDs_agg, hasEPT);
+			}
 		} else {
 			if (indexFiles.size() > 0) {
 				fprintf(stderr, "%d summary index files missing: "


### PR DESCRIPTION
## Summary

Fixes #399 — when all insured losses are zero, wheatsheaf mean EP outputs (`wheatsheaf_mean_aep/oep`) incorrectly contain rows with `summary_id = -1` instead of producing empty output like other report types.

- **`leccalc.cpp`**: Guard the post-loop `outputaggreports` call with `if (last_summary_id != -1)` to prevent the sentinel value from propagating when the summary index file is empty or has no processable data
- **`aggreports.cpp`**: Skip `mean_count` entries where `count == 0` in `WriteWheatsheafMean`, preventing pre-populated but never-filled entries from producing rows with `retperiod=0.0` and `loss=0.0`

## Test plan

- [ ] Build and run existing leccalc tests
- [ ] Verify wheatsheaf mean AEP/OEP outputs are empty (not `summary_id = -1` rows) when all insured losses are zero
- [ ] Verify normal (non-zero loss) wheatsheaf mean outputs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)